### PR TITLE
Fix #7: Avoid match/case syntax to be compatible with python 3.9

### DIFF
--- a/marker/markdown.py
+++ b/marker/markdown.py
@@ -65,21 +65,18 @@ def merge_spans(blocks):
 
 
 def block_surround(text, block_type):
-    match block_type:
-        case "Section-header":
-            if not text.startswith("#"):
-                text = "\n## " + text.strip().title() + "\n"
-        case "Title":
-            if not text.startswith("#"):
-                text = "# " + text.strip().title() + "\n"
-        case "Table":
-            text = "\n" + text + "\n"
-        case "List-item":
-            pass
-        case "Code":
-            text = "\n" + text + "\n"
-        case _:
-            pass
+    if block_type == "Section-header":
+        if not text.startswith("#"):
+            text = "\n## " + text.strip().title() + "\n"
+    elif block_type == "Title":
+        if not text.startswith("#"):
+            text = "# " + text.strip().title() + "\n"
+    elif block_type == "Table":
+        text = "\n" + text + "\n"
+    elif block_type == "List-item":
+        pass
+    elif block_type == "Code":
+        text = "\n" + text + "\n"
     return text
 
 

--- a/marker/ocr/page.py
+++ b/marker/ocr/page.py
@@ -13,13 +13,12 @@ ocrmypdf.configure_logging(verbosity=ocrmypdf.Verbosity.quiet)
 
 
 def ocr_entire_page(page, lang: str, spellchecker: Optional[SpellChecker] = None) -> List[Block]:
-    match settings.OCR_ENGINE:
-        case "tesseract":
-            return ocr_entire_page_tess(page, lang, spellchecker)
-        case "ocrmypdf":
-            return ocr_entire_page_ocrmp(page, lang, spellchecker)
-        case _:
-            raise ValueError(f"Unknown OCR engine {settings.OCR_ENGINE}")
+    if settings.OCR_ENGINE == "tesseract":
+        return ocr_entire_page_tess(page, lang, spellchecker)
+    elif settings.OCR_ENGINE == "ocrmypdf":
+        return ocr_entire_page_ocrmp(page, lang, spellchecker)
+    else:
+        raise ValueError(f"Unknown OCR engine {settings.OCR_ENGINE}")
 
 
 def ocr_entire_page_tess(page, lang: str, spellchecker: Optional[SpellChecker] = None) -> List[Block]:


### PR DESCRIPTION
This makes single page conversion work with Python 3.9 (3.9.2) for me, in other words fixing #7 . I also didn't find any more uses of match/case with some grepping.