### PR TITLE
Bug fix: Work with rotated pdfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The above results are with marker and nougat setup so they each take ~3GB of VRA
 
 See [below](#benchmarks) for detailed speed and accuracy benchmarks, and instructions on how to run your own benchmarks.
 
+# Community
+
+[Discord](https://discord.gg//KuZwXNGnfH) is where we discuss future development.
+
 # Limitations
 
 PDF is a tricky format, so marker will not always work perfectly.  Here are some known limitations that are on the roadmap to address:

--- a/marker/bbox.py
+++ b/marker/bbox.py
@@ -1,3 +1,5 @@
+import fitz as pymupdf
+
 def should_merge_blocks(box1, box2, tol=5):
     # Within tol y px, and to the right within tol px
     merge = [
@@ -59,3 +61,21 @@ def unnormalize_box(bbox, width, height):
         width * (bbox[2] / 1000),
         height * (bbox[3] / 1000),
     ]
+
+
+def correct_rotation(bbox, page):
+    #bbox base is (x0, y0, x1, y1)
+    rotation = page.rotation
+    if rotation == 0:
+        return bbox
+
+    tl = pymupdf.Point(bbox[0], bbox[1]) * page.rotation_matrix
+    br = pymupdf.Point(bbox[2], bbox[3]) * page.rotation_matrix
+    if rotation == 90:
+        bbox = [br[0], tl[1], tl[0], br[1]]
+    elif rotation == 180:
+        bbox = [br[0], br[1], tl[0], tl[1]]
+    elif rotation == 270:
+        bbox = [tl[0], br[1], br[0], tl[1]]
+
+    return bbox

--- a/marker/debug/data.py
+++ b/marker/debug/data.py
@@ -14,6 +14,9 @@ def dump_nougat_debug_data(doc, images, converted_spans):
     if not settings.DEBUG_DATA_FOLDER:
         return
 
+    if len(images) == 0:
+        return
+
     # We attempted one conversion per image
     assert len(converted_spans) == len(images)
 
@@ -37,7 +40,7 @@ def dump_nougat_debug_data(doc, images, converted_spans):
 
     debug_file = os.path.join(settings.DEBUG_DATA_FOLDER, f"{doc_base}_equations.json")
     with open(debug_file, "w+") as f:
-        json.dump(data_lines, f, indent=4)
+        json.dump(data_lines, f)
 
 
 def dump_bbox_debug_data(doc, blocks: List[Page]):
@@ -70,7 +73,7 @@ def dump_bbox_debug_data(doc, blocks: List[Page]):
         debug_data.append(page_data)
 
     with open(debug_file, "w+") as f:
-        json.dump(debug_data, f, indent=4)
+        json.dump(debug_data, f)
 
 
 

--- a/marker/schema.py
+++ b/marker/schema.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, field_validator
 import ftfy
@@ -19,7 +19,6 @@ def find_span_type(span, page_blocks):
 
 class BboxElement(BaseModel):
     bbox: List[float]
-
 
     @field_validator('bbox')
     @classmethod
@@ -134,6 +133,7 @@ class Page(BboxElement):
     blocks: List[Block]
     pnum: int
     column_count: Optional[int] = None
+    rotation: Optional[int] = None # Rotation degrees of the page
 
     def get_nonblank_lines(self):
         lines = self.get_all_lines()

--- a/marker/settings.py
+++ b/marker/settings.py
@@ -54,8 +54,22 @@ class Settings(BaseSettings):
     # Nougat model
     NOUGAT_MODEL_MAX: int = 512 # Max inference length for nougat
     NOUGAT_TOKEN_BUFFER: int = 256 # Number of tokens to buffer above max for nougat
-    NOUGAT_HALLUCINATION_WORDS: List[str] = ["[MISSING_PAGE_POST]", "## References\n", "**Figure Captions**\n", "Footnote",
-                                  "\par\par\par", "## Chapter", "Fig.", "particle", "[REPEATS]", "[TRUNCATED]", "### ", "effective field strength", "\Phi_{\rm eff}"]
+    NOUGAT_HALLUCINATION_WORDS: List[str] = [
+        "[MISSING_PAGE_POST]",
+        "## References\n",
+        "**Figure Captions**\n",
+        "Footnote",
+        "\par\par\par",
+        "## Chapter",
+        "Fig.",
+        "particle",
+        "[REPEATS]",
+        "[TRUNCATED]",
+        "### ",
+        "effective field strength",
+        "\Phi_{\rm eff}",
+        "\mathbf{\mathbf"
+    ]
     NOUGAT_DPI: int = 96 # DPI to render images at, matches default settings for nougat
     NOUGAT_MODEL_NAME: str = "0.1.0-small" # Name of the model to use
     NOUGAT_BATCH_SIZE: int = 6 if TORCH_DEVICE == "cuda" else 1 # Batch size for nougat, don't batch on cpu


### PR DESCRIPTION
- When pdfs are rotated, their bounding box coordinates are not.
- Enables extracting text from pdfs that have been rotated, with appropriate sorting/ordering.

Needs more testing before merging.