### PR TITLE
Use the local nougat model checkpoint.

### DIFF
--- a/marker/cleaners/equations.py
+++ b/marker/cleaners/equations.py
@@ -22,7 +22,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
 def load_nougat_model():
-    ckpt = get_checkpoint(None, model_tag=settings.NOUGAT_MODEL_NAME)
+    ckpt = get_checkpoint(settings.NOUGAT_CHECKPOINT, model_tag=settings.NOUGAT_MODEL_NAME)
     nougat_model = NougatModel.from_pretrained(ckpt)
     if settings.TORCH_DEVICE != "cpu":
         move_to_device(nougat_model, bf16=settings.CUDA, cuda=settings.CUDA)

--- a/marker/settings.py
+++ b/marker/settings.py
@@ -80,6 +80,7 @@ class Settings(BaseSettings):
     ]
     NOUGAT_DPI: int = 96 # DPI to render images at, matches default settings for nougat
     NOUGAT_MODEL_NAME: str = "0.1.0-small" # Name of the model to use
+    NOUGAT_CHECKPOINT: str = None # Path to the checkpoint to use, if None will download from GitHub
     NOUGAT_BATCH_SIZE: int = 6 if TORCH_DEVICE == "cuda" else 1 # Batch size for nougat, don't batch on cpu
 
     # Layout model


### PR DESCRIPTION
Allow using locally downloaded Nought model checkpoints without needing to re-download them.