### PR TITLE
check TORCH_DEVICE for being None

### DIFF
--- a/marker/settings.py
+++ b/marker/settings.py
@@ -112,7 +112,7 @@ class Settings(BaseSettings):
     @computed_field
     @property
     def CUDA(self) -> bool:
-        return "cuda" in self.TORCH_DEVICE
+        return self.TORCH_DEVICE is not None and "cuda" in self.TORCH_DEVICE
 
     @computed_field
     @property


### PR DESCRIPTION
Hey there, fixed a small bug (`TypeError: argument of type 'NoneType' is not iterable`) in settings.py. Maybe you're interested?