### PR TITLE
Replace newlines with HTML line breaks in table cells

### DIFF
--- a/marker/tables/table.py
+++ b/marker/tables/table.py
@@ -173,6 +173,11 @@ def format_tables(pages: List[Page]):
             if len(table_rows) == 0:
                 continue
 
+            table_rows = [
+                [cell.replace('\n', ' <br> ') if '\n' in cell else cell for cell in row]
+                for row in table_rows
+            ]
+
             table_text = tabulate(table_rows, headers="firstrow", tablefmt="github", disable_numparse=True)
             table_block = Block(
                 bbox=table_box,


### PR DESCRIPTION
## Description
This PR addresses an issue where newline characters in table cells were breaking the markdown table structure. By replacing `\n` with ` <br> `, we maintain the visual line breaks within cells while preserving the overall table format.

## Changes made
- Added a list comprehension to process each cell in the table rows
- Replaced `\n` with ` <br> ` in cells that contain newline characters

## Why this change is necessary
Without this change, newline characters in table cells would disrupt the markdown table structure, leading to incorrect rendering of tables in the output. This fix ensures that tables are displayed correctly while maintaining the intended line breaks within cells.

## Testing
Please verify that tables containing cells with multiple lines are now rendered correctly in the markdown output.

Let me know if you need any further information or changes to this PR.