### PR TITLE
Fix encofing in metadata output

### DIFF
--- a/marker/output.py
+++ b/marker/output.py
@@ -29,7 +29,7 @@ def save_markdown(out_folder, fname, full_text, images, out_metadata):
 
     with open(markdown_filepath, "w+", encoding='utf-8') as f:
         f.write(full_text)
-    with open(out_meta_filepath, "w+") as f:
+    with open(out_meta_filepath, "w+", encoding='utf-8') as f:
         f.write(json.dumps(out_metadata, indent=4, ensure_ascii=False))
 
     for filename, image in images.items():


### PR DESCRIPTION
Similarly as two line above, the metadata file can fail if it has non ascii characters, like in my french file.

![Selection_1167](https://github.com/user-attachments/assets/970050c6-8eb6-4c98-b918-b84c747383c4)

