### PR TITLE
add ocr_idxs as additional information to out_meta

### DIFF
--- a/marker/convert.py
+++ b/marker/convert.py
@@ -45,7 +45,8 @@ def convert_single_pdf(
         metadata: Optional[Dict] = None,
         langs: Optional[List[str]] = None,
         batch_multiplier: int = 1,
-        ocr_all_pages: bool = False
+        ocr_all_pages: bool = False,
+        sort_by_reading_order: bool = False,
 ) -> Tuple[str, Dict[str, Image.Image], Dict]:
     ocr_all_pages = ocr_all_pages or settings.OCR_ALL_PAGES
 
@@ -113,7 +114,8 @@ def convert_single_pdf(
 
     # Sort from reading order
     surya_order(lowres_images, pages, order_model, batch_multiplier=batch_multiplier)
-    sort_blocks_in_reading_order(pages)
+    if sort_by_reading_order:
+        sort_blocks_in_reading_order(pages)
 
     # Dump debug data if flags are set
     draw_page_debug_images(fname, pages)

--- a/marker/ocr/recognition.py
+++ b/marker/ocr/recognition.py
@@ -44,11 +44,11 @@ def run_ocr(doc, pages: List[Page], langs: List[str], rec_model, batch_multiplie
 
     # No pages need OCR
     if ocr_pages == 0:
-        return pages, {"ocr_pages": 0, "ocr_failed": 0, "ocr_success": 0, "ocr_engine": "none"}
+        return pages, {"ocr_pages": 0, "ocr_failed": 0, "ocr_success": 0, "ocr_engine": "none", "ocr_idxs": ocr_idxs}
 
     ocr_method = settings.OCR_ENGINE
     if ocr_method is None or ocr_method == "None":
-        return pages, {"ocr_pages": 0, "ocr_failed": 0, "ocr_success": 0, "ocr_engine": "none"}
+        return pages, {"ocr_pages": 0, "ocr_failed": 0, "ocr_success": 0, "ocr_engine": "none", "ocr_idxs": ocr_idxs}
     elif ocr_method == "surya":
         new_pages = surya_recognition(doc, ocr_idxs, langs, rec_model, pages, batch_multiplier=batch_multiplier)
     elif ocr_method == "ocrmypdf":
@@ -63,7 +63,7 @@ def run_ocr(doc, pages: List[Page], langs: List[str], rec_model, batch_multiplie
             ocr_success += 1
             pages[orig_idx] = page
 
-    return pages, {"ocr_pages": ocr_pages, "ocr_failed": ocr_failed, "ocr_success": ocr_success, "ocr_engine": ocr_method}
+    return pages, {"ocr_pages": ocr_pages, "ocr_failed": ocr_failed, "ocr_success": ocr_success, "ocr_engine": ocr_method, "ocr_idxs": ocr_idxs}
 
 
 def surya_recognition(doc, page_idxs, langs: List[str], rec_model, pages: List[Page], batch_multiplier=1) -> List[Optional[Page]]:


### PR DESCRIPTION
I have added the list of page numbers, that needed OCR to the ocr_stats dictionary that is returned by the run_ocr function. This information could be important for further processing of OCR processed pages.