### PR TITLE
Fix chunk_convert.sh to handle output_dir correctly

### DIFF
--- a/chunk_convert.sh
+++ b/chunk_convert.sh
@@ -13,7 +13,6 @@ if [[ -z "$NUM_WORKERS" ]]; then
     exit 1
 fi
 
-
 # Get input folder and output folder from args
 if [[ -z "$1" ]]; then
     echo "Please provide an input folder."
@@ -28,14 +27,17 @@ fi
 INPUT_FOLDER=$1
 OUTPUT_FOLDER=$2
 
-# Loop from 0 to NUM_DEVICES and run the Python script in parallel
+# Ensure output folder exists
+mkdir -p "$OUTPUT_FOLDER"
+
+# Loop from 0 to NUM_DEVICES and run the marker command in parallel
 for (( i=0; i<$NUM_DEVICES; i++ )); do
     DEVICE_NUM=$i
     export DEVICE_NUM
     export NUM_DEVICES
     export NUM_WORKERS
-    echo "Running convert.py on GPU $DEVICE_NUM"
-    cmd="CUDA_VISIBLE_DEVICES=$DEVICE_NUM marker $INPUT_FOLDER $OUTPUT_FOLDER --num_chunks $NUM_DEVICES --chunk_idx $DEVICE_NUM --workers $NUM_WORKERS"
+    echo "Running marker on GPU $DEVICE_NUM"
+    cmd="CUDA_VISIBLE_DEVICES=$DEVICE_NUM marker $INPUT_FOLDER --output_dir $OUTPUT_FOLDER --num_chunks $NUM_DEVICES --chunk_idx $DEVICE_NUM --workers $NUM_WORKERS"
     eval $cmd &
 
     sleep 5


### PR DESCRIPTION
Fixes  #414

Running the command for multiple devices and multiple files leads to an error:

```
NUM_DEVICES=2 NUM_WORKERS=15 marker_chunk_convert /tmp/marker_input /tmp/marker_output
Running convert.py on GPU 0
Usage: marker [OPTIONS] IN_FOLDER
Try 'marker --help' for help.

Error: Got unexpected extra argument (/tmp/marker_output)
```

This pull request fixes the bash script and calls marker correctly. I also added a line which makes sure the output folder exists, and creates it if not. 