### PR TITLE
WIP feat: accept binary PDF instead of just path to PDF

### DIFF
--- a/marker/processors/debug.py
+++ b/marker/processors/debug.py
@@ -49,7 +49,8 @@ class DebugProcessor(BaseProcessor):
 
     def __call__(self, document: Document):
         # Remove extension from doc name
-        doc_base = os.path.basename(document.filepath).rsplit(".", 1)[0]
+        filepath = document.filepath if isinstance(document.filepath, str) else ""
+        doc_base = os.path.basename(filepath).rsplit(".", 1)[0]
         self.debug_folder = os.path.join(self.debug_data_folder, doc_base)
         if any([self.debug_layout_images, self.debug_pdf_images, self.debug_json]):
             os.makedirs(self.debug_folder, exist_ok=True)

--- a/marker/providers/__init__.py
+++ b/marker/providers/__init__.py
@@ -19,7 +19,7 @@ class ProviderOutput(BaseModel):
 ProviderPageLines = Dict[int, List[ProviderOutput]]
 
 class BaseProvider:
-    def __init__(self, filepath: str, config: Optional[BaseModel | dict] = None):
+    def __init__(self, filepath: str | bytes, config: Optional[BaseModel | dict] = None):
         assign_config(self, config)
         self.filepath = filepath
 

--- a/marker/providers/pdf.py
+++ b/marker/providers/pdf.py
@@ -26,8 +26,8 @@ class PdfProvider(BaseProvider):
     ocr_newline_threshold: float = .6
     ocr_alphanum_threshold: float = .3
 
-    def __init__(self, filepath: str, config=None):
-        super().__init__(filepath, config)
+    def __init__(self, file: str | bytes, config=None):
+        super().__init__(file, config)
 
         self.doc: pdfium.PdfDocument = pdfium.PdfDocument(self.filepath)
         self.page_lines: ProviderPageLines = {i: [] for i in range(len(self.doc))}

--- a/marker/schema/document.py
+++ b/marker/schema/document.py
@@ -23,7 +23,7 @@ class TocItem(BaseModel):
 
 
 class Document(BaseModel):
-    filepath: str
+    filepath: str | bytes
     pages: List[PageGroup]
     block_type: BlockTypes = BlockTypes.Document
     table_of_contents: List[TocItem] | None = None


### PR DESCRIPTION
While the library expects a filepath to be given to the PdfConverter, the underlying pdfium.PdfDocument constructor supports bytes and other types. Adding 'bytes' as an accepted type for the Document Pydantic model allows binary PDFs to be parsed by the library.

I've tested this patch manually and things seem to work fine so far, but I'd prefer to add tests for it. However the test suite seems to be heavily built around creating a temporary file, and I'm not sure where to start to test this