### PR TITLE
Enhance Config Parsing by Allowing Direct Input of Additional Parameters via cli_options

### DIFF
--- a/marker/config/parser.py
+++ b/marker/config/parser.py
@@ -69,6 +69,9 @@ class ConfigParser:
                 case "disable_image_extraction":
                     if v:
                         config["extract_images"] = False
+                case _:
+                    if v:
+                        config[k] = v
         return config
 
     def get_renderer(self):


### PR DESCRIPTION
The purpose of this PR is to enhance the flexibility of parsing input parameters. In the current case match logic, if users need to pass additional parameters, they must first create a JSON file and provide its file path as the value of the config_json key. This PR modifies the case match logic to allow users to directly pass additional configuration parameters (e.g., layout model parameters, OCR model parameters, etc.) through cli_options, without relying on an external JSON file.