### PR TITLE
Add context manager support for PdfProvider

### DIFF
--- a/marker/providers/pdf.py
+++ b/marker/providers/pdf.py
@@ -85,6 +85,12 @@ class PdfProvider(BaseProvider):
 
         atexit.register(self.cleanup_pdf_doc)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cleanup_pdf_doc()
+
     def __len__(self) -> int:
         return len(self.doc)
 


### PR DESCRIPTION
PdfProvider does not close the underlying PyPDFium handles until program exit, which leaves too many open file handles even when the object is no longer in scope. Adding context manager support and using this in PdfConverter fixes

`build_document` also caches the document to support multiple calls over the same document.

Fixes #432 
