### PR TITLE
Fix link to Surya supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Options:
 - `config --help`: List all available builders, processors, and converters, and their associated configuration.  These values can be used to build a JSON configuration file for additional tweaking of marker defaults.
 - `--converter_cls`: One of `marker.converters.pdf.PdfConverter` (default) or `marker.converters.table.TableConverter`.  The `PdfConverter` will convert the whole PDF, the `TableConverter` will only extract and convert tables.
 
-The list of supported languages for surya OCR is [here](https://github.com/VikParuchuri/surya/blob/master/surya/languages.py).  If you don't need OCR, marker can work with any language.
+The list of supported languages for surya OCR is [here](https://github.com/VikParuchuri/surya/blob/master/surya/recognition/languages.py).  If you don't need OCR, marker can work with any language.
 
 ## Convert multiple files
 

--- a/marker/scripts/server.py
+++ b/marker/scripts/server.py
@@ -62,7 +62,7 @@ class CommonParams(BaseModel):
     ] = None
     languages: Annotated[
         Optional[str],
-        Field(description="Comma separated list of languages to use for OCR. Must be either the names or codes from from https://github.com/VikParuchuri/surya/blob/master/surya/languages.py.", example=None)
+        Field(description="Comma separated list of languages to use for OCR. Must be either the names or codes from from https://github.com/VikParuchuri/surya/blob/master/surya/recognition/languages.py.", example=None)
     ] = None
     force_ocr: Annotated[
         bool,


### PR DESCRIPTION
Clicking on the current "supported languages" returns in a 404 error.

Slightly refers to #431

`CODE_TO_LANGUAGE` constant has been moved to a different location in VikParuchuri/surya@1de6d91