### PR TITLE
Fix use_llm parameter in PdfConverter to default to Google Gemini.

### DIFF
--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -115,7 +115,7 @@ class PdfConverter(BaseConverter):
         if llm_service:
             llm_service_cls = strings_to_classes([llm_service])[0]
             llm_service = self.resolve_dependencies(llm_service_cls)
-        elif config.get("use_llm", False):
+        elif config.get("use_llm", True):
             llm_service = self.resolve_dependencies(GoogleGeminiService)
 
         # Inject llm service into artifact_dict so it can be picked up by processors, etc.


### PR DESCRIPTION
I believe the logic should be that `llm_service` defaults to `GoogleGeminiService` if `use_llm` is set to `True` instead of `False`.