### PR TITLE
Fix character encoding issues when loading JSON configuration files

### DIFF
--- a/marker/config/parser.py
+++ b/marker/config/parser.py
@@ -65,7 +65,7 @@ class ConfigParser:
                 case "languages":
                     config["languages"] = v.split(",")
                 case "config_json":
-                    with open(v, "r") as f:
+                    with open(v, "r", encoding="utf-8") as f:
                         config.update(json.load(f))
                 case "disable_multiprocessing":
                     config["pdftext_workers"] = 1

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -175,6 +175,14 @@
       "created_at": "2025-02-15T19:11:32Z",
       "repoId": 712111618,
       "pullRequestNo": 552
+    },
+    {
+      "name": "dantetemplar",
+      "id": 69670642,
+      "comment_id": 2661665606,
+      "created_at": "2025-02-16T23:02:34Z",
+      "repoId": 712111618,
+      "pullRequestNo": 555
     }
   ]
 }


### PR DESCRIPTION
## Problem Description
When loading configuration files containing non-ASCII characters (like Spanish accents or special characters), the text is incorrectly encoded, resulting in mojibake (e.g., "ó" appearing as "Ã³"). This affects all text loaded from JSON configuration files, including prompts for LLM services.

### Example of the issue:
```json
{
    "LLMImageDescriptionProcessor_image_description_prompt": "Eres un experto en análisis de documentos especializado en crear descripciones de texto para imágenes. (...)"
}
```
Was being loaded as:
```text
Eres un experto en anÃ¡lisis de documentos especializado en crear descripciones de texto para imÃ¡genes. (...)
```

And the LLM's response was, for example: 

```text
Esta imagen muestra el escudo de la Pontificia Universidad CatÃ³lica de Chile.
```

## Root Cause
The JSON configuration files were being opened without explicitly specifying UTF-8 encoding, causing the text to be read with the system's default encoding.

## Solution
Modified the configuration file loading in `config/parser.py` to explicitly use UTF-8 encoding when opening JSON files. This is particularly important for non-English LLM prompts and responses.