### PR TITLE
Increased Windows support, and add option to not use multiprocessing

### DIFF
--- a/marker/scripts/convert.py
+++ b/marker/scripts/convert.py
@@ -111,6 +111,15 @@ def convert_cli(in_folder: str, **kwargs):
 
     total_processes = min(len(files_to_convert), kwargs["workers"])
 
+    if total_processes == 0:
+        # Disable multiprocessing
+        global model_refs
+        model_refs = create_model_dict()
+        for f in tqdm(files_to_convert):
+            process_single_pdf((f, kwargs))
+        del model_refs
+        return
+
     try:
         mp.set_start_method('spawn') # Required for CUDA, forkserver doesn't work
     except RuntimeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+import uuid
 from marker.providers.pdf import PdfProvider
 import tempfile
 from typing import Dict, Type
@@ -86,10 +88,13 @@ def temp_doc(request, pdf_dataset):
     idx = pdf_dataset['filename'].index(filename)
     suffix = filename.split(".")[-1]
 
-    temp_pdf = tempfile.NamedTemporaryFile(suffix=f".{suffix}")
-    temp_pdf.write(pdf_dataset['pdf'][idx])
-    temp_pdf.flush()
-    yield temp_pdf
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_pdf_path = os.path.join(temp_dir, f"temp.{suffix}")  # Randomized filename
+        
+        with open(temp_pdf_path, "wb") as temp_pdf:
+            temp_pdf.write(pdf_dataset['pdf'][idx])
+            temp_pdf.flush()
+            yield temp_pdf
 
 
 @pytest.fixture(scope="function")
@@ -148,7 +153,8 @@ def temp_image():
     img = Image.new("RGB", (512, 512), color="white")
     draw = ImageDraw.Draw(img)
     draw.text((10, 10), "Hello, World!", fill="black", font_size=24)
-    with tempfile.NamedTemporaryFile(suffix=".png") as f:
-        img.save(f.name)
-        f.flush()
-        yield f
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_png_path = os.path.join(temp_dir, f"{uuid.uuid4()}.png")  # Randomized filename
+        img.save(temp_png_path)
+        with open(temp_png_path, "rb") as f:
+            yield f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def temp_doc(request, pdf_dataset):
     suffix = filename.split(".")[-1]
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_pdf_path = os.path.join(temp_dir, f"temp.{suffix}")  # Randomized filename
+        temp_pdf_path = os.path.join(temp_dir, f"{uuid.uuid4()}.{suffix}")  # Randomized filename
         
         with open(temp_pdf_path, "wb") as temp_pdf:
             temp_pdf.write(pdf_dataset['pdf'][idx])


### PR DESCRIPTION
This PR adds an option to disable multiprocessing for the `marker` cli by setting `--workers 0`. The semantics is the same as setting `num_workers=0` for a pytorch dataloader.

This is a workaround for #242 and #617: while it doesn't fix the underlying issue, it provides an option to allow marker to execute in a single-threaded manner.

This PR also adjusts `conftest.py` to allow the tests to run on windows.

