### PR TITLE
Format Lines: Fix line merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Options:
 - `--debug`: Enable debug mode for additional logging and diagnostic information.
 - `--processors TEXT`: Override the default processors by providing their full module paths, separated by commas. Example: `--processors "module1.processor1,module2.processor2"`
 - `--config_json PATH`: Path to a JSON configuration file containing additional settings.
-- `--languages TEXT`: Optionally specify which languages to use for OCR processing. Accepts a comma-separated list. Example: `--languages "en,fr,de"` for English, French, and German.
 - `config --help`: List all available builders, processors, and converters, and their associated configuration.  These values can be used to build a JSON configuration file for additional tweaking of marker defaults.
 - `--converter_cls`: One of `marker.converters.pdf.PdfConverter` (default) or `marker.converters.table.TableConverter`.  The `PdfConverter` will convert the whole PDF, the `TableConverter` will only extract and convert tables.
 - `--llm_service`: Which llm service to use if `--use_llm` is passed.  This defaults to `marker.services.gemini.GoogleGeminiService`.

--- a/marker/builders/layout.py
+++ b/marker/builders/layout.py
@@ -98,19 +98,16 @@ class LayoutBuilder(BaseBuilder):
                 if block.block_type in self.expand_block_types:
                     other_blocks = [b for b in page_blocks if b != block]
                     if not other_blocks:
-                        print(f'Expanding {block_id} by {(self.max_expand_frac, self.max_expand_frac)}')
                         block.polygon = block.polygon.expand(self.max_expand_frac, self.max_expand_frac)
                         continue
 
                     min_gap = min(block.polygon.minimum_gap(other.polygon) for other in other_blocks)
                     if min_gap <= 0:
-                        print(f'Cannot expand {block_id}')
                         continue
 
                     x_expand_frac = min_gap / block.polygon.width if block.polygon.width > 0 else 0
                     y_expand_frac = min_gap / block.polygon.height if block.polygon.height > 0 else 0
 
-                    print(f'Expanding {block_id} by {(min(x_expand_frac, self.max_expand_frac), min(y_expand_frac, self.max_expand_frac))}')
                     block.polygon = block.polygon.expand(x_expand_frac, y_expand_frac)
 
     def add_blocks_to_pages(

--- a/marker/builders/layout.py
+++ b/marker/builders/layout.py
@@ -31,6 +31,14 @@ class LayoutBuilder(BaseBuilder):
         bool,
         "Disable tqdm progress bars.",
     ] = False
+    expand_block_types: Annotated[
+        List[BlockTypes],
+        "Block types whose bounds should be expanded to accomodate missing regions"
+    ] = [BlockTypes.Picture, BlockTypes.Figure, BlockTypes.ComplexRegion] # Does not include groups since they are only injected later
+    expand_frac: Annotated[
+        float,
+        "The fraction to expand the layout box bounds by"
+    ] = 0.02
 
     def __init__(self, layout_model: LayoutPredictor, config=None):
         self.layout_model = layout_model
@@ -96,6 +104,8 @@ class LayoutBuilder(BaseBuilder):
                 layout_block.polygon = layout_block.polygon.rescale(
                     layout_page_size, provider_page_size
                 )
+                if layout_block.block_type in self.expand_block_types:
+                    layout_block.polygon = layout_block.polygon.expand(self.expand_frac, self.expand_frac)
                 layout_block.top_k = {
                     BlockTypes[label]: prob for (label, prob) in bbox.top_k.items()
                 }

--- a/marker/builders/line.py
+++ b/marker/builders/line.py
@@ -394,9 +394,29 @@ class LineBuilder(BaseBuilder):
         page_size,
         page_id,
     ):
-        # When provider lines is empty or no lines detected, return provider lines
-        if not provider_lines or not text_lines:
-            return provider_lines
+        # If no lines detected, skip the merging
+        if not text_lines:
+            return provider_lines, []
+        
+        # If no provider lines, return all detected text lines
+        if not provider_lines:
+            detected_only_lines = []
+            LineClass: Line = get_block_class(BlockTypes.Line)
+            for text_line in text_lines:
+                text_line_polygon = PolygonBox(polygon=text_line.polygon).rescale(image_size, page_size)
+                detected_only_lines.append(
+                    ProviderOutput(
+                        line=LineClass(
+                            polygon=text_line_polygon,
+                            page_id=page_id,
+                            text_extraction_method="surya"
+                        ),
+                        spans=[],
+                        chars=[]
+                    )
+                )
+
+            return out_provider_lines, detected_only_lines
 
         out_provider_lines = []
         horizontal_provider_lines = []

--- a/marker/builders/line.py
+++ b/marker/builders/line.py
@@ -479,7 +479,11 @@ class LineBuilder(BaseBuilder):
         ):
             # Don't just take the whole detected line if we have multiple sections inside
             if len(all_merge_sections) == 1:
-                return text_line.rescale(image_size, page_size)
+                text_line_overlaps = np.nonzero(overlaps[merge_section[0]])[0].tolist()
+                merged_text_line: PolygonBox = text_lines[text_line_overlaps[0]]
+                if len(text_line_overlaps) > 1:
+                    merged_text_line =  merged_text_line.merge([text_lines[k] for k in text_line_overlaps[1:]])
+                return merged_text_line.rescale(image_size, page_size)
             else:
                 poly = None
                 for section_idx in merge_section:

--- a/marker/builders/ocr.py
+++ b/marker/builders/ocr.py
@@ -100,7 +100,7 @@ class OcrBuilder(BaseBuilder):
                 block_lines_to_ocr = [
                     block_line
                     for block_line in block_lines
-                    if block_line.text_extraction_method == "surya"
+                    if block_line.text_extraction_method in ["surya", "hybrid"]
                 ]
 
                 # Set extraction method of OCR-only pages

--- a/marker/builders/ocr.py
+++ b/marker/builders/ocr.py
@@ -35,6 +35,7 @@ class OcrBuilder(BaseBuilder):
         bool,
         "Disable tqdm progress bars.",
     ] = False
+    # We can skip tables here, since the TableProcessor will re-OCR
     skip_ocr_blocks: Annotated[
         List[BlockTypes],
         "Blocktypes for which contained lines are not processed by the OCR model"

--- a/marker/builders/ocr.py
+++ b/marker/builders/ocr.py
@@ -39,7 +39,7 @@ class OcrBuilder(BaseBuilder):
         List[BlockTypes],
         "Blocktypes for which contained lines are not processed by the OCR model"
         "By default, this avoids recognizing lines inside equations",
-    ] = BlockTypes.Equation
+    ] = [BlockTypes.Equation, BlockTypes.Figure, BlockTypes.FigureGroup, BlockTypes.Picture, BlockTypes.PictureGroup, BlockTypes.Table]
     ocr_task_name: Annotated[
         str,
         "The OCR mode to use, see surya for details.  Set to 'ocr_without_boxes' for potentially better performance, at the expense of formatting.",

--- a/marker/builders/ocr.py
+++ b/marker/builders/ocr.py
@@ -39,7 +39,7 @@ class OcrBuilder(BaseBuilder):
     skip_ocr_blocks: Annotated[
         List[BlockTypes],
         "Blocktypes for which contained lines are not processed by the OCR model"
-        "By default, this avoids recognizing lines inside equations",
+        "By default, this avoids recognizing lines inside equations, figures, and pictures",
     ] = [BlockTypes.Equation, BlockTypes.Figure, BlockTypes.FigureGroup, BlockTypes.Picture, BlockTypes.PictureGroup, BlockTypes.Table]
     ocr_task_name: Annotated[
         str,

--- a/marker/schema/groups/page.py
+++ b/marker/schema/groups/page.py
@@ -12,7 +12,7 @@ from marker.schema.blocks import Block, BlockId, Text
 from marker.schema.blocks.base import BlockMetadata
 from marker.schema.groups.base import Group
 from marker.schema.polygon import PolygonBox
-from marker.util import matrix_intersection_area
+from marker.util import matrix_intersection_area, sort_text_lines
 
 LINE_MAPPING_TYPE = List[Tuple[int, ProviderOutput]]
 
@@ -244,9 +244,19 @@ class PageGroup(Group):
     ):
         # Add lines to the proper blocks, sorted in order
         for block_id, lines in block_lines.items():
-            lines = sorted(lines, key=lambda x: x[0])
+            line_extraction_methods = set([l[1].line.text_extraction_method for l in lines])
+            if len(line_extraction_methods) == 1:
+                lines = sorted(lines, key=lambda x: x[0])
+                lines = [l for _, l in lines]
+            else:
+                lines = [l for _, l in lines]
+                line_polygons = [l.line.polygon for l in lines]
+                sorted_line_polygons = sort_text_lines(line_polygons)
+                argsort = [line_polygons.index(p) for p in sorted_line_polygons]
+                lines = [lines[i] for i in argsort]
+
             block = self.get_block(block_id)
-            for line_idx, provider_output in lines:
+            for provider_output in lines:
                 line = provider_output.line
                 spans = provider_output.spans
                 self.add_full_block(line)

--- a/tests/builders/test_line_builder.py
+++ b/tests/builders/test_line_builder.py
@@ -1,0 +1,24 @@
+import pytest
+
+from marker.schema import BlockTypes
+
+# Page contains provider lines that are longer than detected lines
+# Any bad merging will cause broken final OCR results with format lines
+@pytest.mark.filename("mixed_eng_hindi.pdf")
+@pytest.mark.config({"page_range": [2], "format_lines": True})
+def test_provider_detected_line_merge(pdf_document):
+    page = pdf_document.pages[0]
+    text_lines = page.contained_blocks(pdf_document, (BlockTypes.Line,))
+
+    # This count includes detected lines merged in with provider lines
+    assert len(text_lines) == 83
+
+# Page provider lines only contain english, while the hindi is missing
+# format_lines should fill in the missing lines
+@pytest.mark.filename("mixed_eng_hindi.pdf")
+@pytest.mark.config({"page_range": [0], "format_lines": True})
+def test_fill_missing_provider_lines(pdf_document):
+    page = pdf_document.pages[0]
+    raw_text = page.raw_text(pdf_document)
+    assert "प्राधिकार से प्रकाशित" in raw_text
+    assert "खान मंत्रालय" in raw_text


### PR DESCRIPTION
We may have detected text that _is not_ covered by any provider line. We ideally don't want to lose out on these lines in `format_lines` model. This arises in two cases - One off lines, _and_ when the layout check fails. This PR:

- Fixes bugs in line merging
  - [x] Adds in text detection boxes where there is no provider line. 
  - [x] Corrects the sorting when a layout box contains lines from both sources
  - [x] Filters out detection lines from layout boxes that won't use them'
  - [x] Covers the reverse case - When multiple detection lines belong to the same `pdftext` provider line

- Adds an initial implementation for box expansion to avoid picture/figure blocks being cut off
- Updates README to remove deprecated `--languages` flag