### PR TITLE
fix: don't remove leading newlines when paginate=True for markdown

### DIFF
--- a/marker/renderers/markdown.py
+++ b/marker/renderers/markdown.py
@@ -29,13 +29,11 @@ def cleanup_text(full_text):
     ends_with_pagination = re.search(r'\{\d+\}[^\n]*\n*$', full_text)
     
     if starts_with_pagination and ends_with_pagination:
-        return full_text  # Don't strip either end
+        return full_text  # Don't strip either end (blank last page)
     elif starts_with_pagination:
-        return full_text.rstrip()  # Only strip trailing
-    elif ends_with_pagination:
-        return full_text.lstrip()  # Only strip leading
+        return full_text.rstrip()  # Only strip trailing (normal pagination)
     else:
-        return full_text.strip()  # Strip both as before
+        return full_text.strip()  # Strip both (no pagination)
 
 
 def get_formatted_table_text(element):

--- a/tests/renderers/test_markdown_renderer.py
+++ b/tests/renderers/test_markdown_renderer.py
@@ -23,6 +23,20 @@ def test_markdown_renderer_pagination(pdf_document):
     assert "\n\n{1}-" in md
 
 
+@pytest.mark.config({"page_range": [0, 1], "paginate_output": True})
+def test_markdown_renderer_pagination_blank_last_page(pdf_document):
+    # Clear all children and structure from the last page to simulate a blank page
+    last_page = pdf_document.pages[-1]
+    last_page.children = []
+    last_page.structure = []
+    
+    renderer = MarkdownRenderer({"paginate_output": True})
+    md = renderer(pdf_document).markdown
+    
+    # Should end with pagination marker and preserve trailing newlines
+    assert md.endswith("}\n\n") or md.endswith("}------------------------------------------------\n\n")
+
+
 @pytest.mark.config({"page_range": [0, 1]})
 def test_markdown_renderer_metadata(pdf_document):
     renderer = MarkdownRenderer({"paginate_output": True})


### PR DESCRIPTION
in @marker/renderers/markdown.py when paginate is true, marker is supposed to add `2 newlines, {PAGE_NUMBER}, 48 - characters, 2 newlines`. however the function [cleanup_text](https://github.com/datalab-to/marker/blob/ab1d11516359f501ed9b3d96de2c1c0dce7038c7/marker/renderers/markdown.py#L26) strips the leading newlines. this fixes that edge case and updates the tests