### PR TITLE
Fix: show tqdm total iteration count

### DIFF
--- a/marker/processors/llm/__init__.py
+++ b/marker/processors/llm/__init__.py
@@ -156,7 +156,9 @@ class BaseLLMComplexBlockProcessor(BaseLLMProcessor):
             return
 
         pbar = tqdm(
-            desc=f"{self.__class__.__name__} running", disable=self.disable_tqdm
+            total=total_blocks,
+            desc=f"{self.__class__.__name__} running",
+            disable=self.disable_tqdm
         )
         with ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
             for future in as_completed(

--- a/marker/processors/llm/llm_mathblock.py
+++ b/marker/processors/llm/llm_mathblock.py
@@ -142,7 +142,9 @@ Adversarial training <i>(AT)</i> <a href='#page-9-1'>[23]</a>, which aims to min
             return
 
         pbar = tqdm(
-            desc=f"{self.__class__.__name__} running", disable=self.disable_tqdm
+            total=total_blocks,
+            desc=f"{self.__class__.__name__} running",
+            disable=self.disable_tqdm
         )
         with ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
             for future in as_completed(

--- a/marker/processors/llm/llm_table_merge.py
+++ b/marker/processors/llm/llm_table_merge.py
@@ -158,8 +158,7 @@ Table 2
         if self.no_merge_tables_across_pages:
             logger.info("Skipping table merging across pages due to --no_merge_tables_across_pages flag")
             return
-            
-        pbar = tqdm(desc=f"{self.__class__.__name__} running", disable=self.disable_tqdm)
+
         table_runs = []
         table_run = []
         prev_block = None
@@ -220,6 +219,17 @@ Table 2
 
         if table_run:
             table_runs.append(table_run)
+
+        # Don't show progress if there is nothing to process
+        total_table_runs = len(table_runs)
+        if total_table_runs == 0:
+            return
+
+        pbar = tqdm(
+            total=total_table_runs,
+            desc=f"{self.__class__.__name__} running",
+            disable=self.disable_tqdm,
+        )
 
         with ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
             for future in as_completed([


### PR DESCRIPTION
There are three cases where there are set up `tqdm` progress bars, and where the total iteration count is known, but not displayed.

The changes in this PR tells `tqdm` how many iterations is going to happen, which will show progressbars instead of:
> LLMTableMergeProcessor running: 6it [00:41,  6.91s/it]

I've also moved the progressbar in `marker/processors/llm/llm_table_merge.py` further down, such that we know how much is going to be processed before showing the progressbar. With this, no progressbar will show if there is nothing to process. I've implemented this in the same way it is implemented for the progressbars in the other files.