### PR TITLE
feat: table ocr confidence added

### DIFF
--- a/marker/processors/table.py
+++ b/marker/processors/table.py
@@ -142,6 +142,8 @@ class TableProcessor(BaseProcessor):
             for block in page.contained_blocks(document, self.block_types):
                 block.structure = []  # Remove any existing lines, spans, etc.
                 cells: List[SuryaTableCell] = tables[table_idx].cells
+                table_confidence = self.calculate_table_confidence(cells)
+                block.table_confidence = table_confidence
                 for cell in cells:
                     # Rescale the cell polygon to the page size
                     cell_polygon = PolygonBox(polygon=cell.polygon).rescale(
@@ -153,9 +155,11 @@ class TableProcessor(BaseProcessor):
                         corner[0] += block.polygon.bbox[0]
                         corner[1] += block.polygon.bbox[1]
 
+                    cell_confidence = self.calculate_cell_confidence(cell)
                     cell_block = TableCell(
                         polygon=cell_polygon,
                         text_lines=self.finalize_cell_text(cell),
+                        confidence=cell_confidence,
                         rowspan=cell.rowspan,
                         colspan=cell.colspan,
                         row_id=cell.row_id,
@@ -690,7 +694,7 @@ class TableProcessor(BaseProcessor):
             for cell_text, cell_needs_text in zip(ocr_res.text_lines, cells_need_text):
                 # Don't need to correct back to image size
                 # Table rec boxes are relative to the table
-                cell_text_lines = [{"text": t} for t in cell_text.text.split("<br>")]
+                cell_text_lines = [{"text": t, "confidence": cell_text.confidence} for t in cell_text.text.split("<br>")]
                 cell_needs_text.text_lines = cell_text_lines
 
     def get_table_rec_batch_size(self):
@@ -717,3 +721,34 @@ class TableProcessor(BaseProcessor):
         elif settings.TORCH_DEVICE_MODEL == "cuda":
             return 10
         return 4
+
+    def calculate_table_confidence(self, table_cells: List[SuryaTableCell]) -> float:
+        if not table_cells:
+            return 0.0
+        
+        total_confidence = 0.0
+        cell_count = 0
+        
+        for cell in table_cells:
+            if cell.text_lines:
+                cell_confidences = []
+                for line in cell.text_lines:
+                    if isinstance(line, dict) and "confidence" in line:
+                        cell_confidences.append(line["confidence"])
+                
+                if cell_confidences:
+                    total_confidence += sum(cell_confidences) / len(cell_confidences)
+                    cell_count += 1
+        
+        return total_confidence / cell_count if cell_count > 0 else 0.0
+
+    def calculate_cell_confidence(self, cell: SuryaTableCell) -> float:
+        if not cell.text_lines:
+            return 0.0
+        
+        confidences = []
+        for line in cell.text_lines:
+            if isinstance(line, dict) and "confidence" in line:
+                confidences.append(line["confidence"])
+        
+        return sum(confidences) / len(confidences) if confidences else 0.0

--- a/marker/renderers/json.py
+++ b/marker/renderers/json.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict, List, Tuple
+from typing import Annotated, Dict, List, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -15,13 +15,22 @@ class JSONBlockOutput(BaseModel):
     html: str
     polygon: List[List[float]]
     bbox: List[float]
-    children: List["JSONBlockOutput"] | None = None
+    children: List["JSONBlockOutputType"] | None = None
     section_hierarchy: Dict[int, str] | None = None
     images: dict | None = None
 
 
+class JSONTableCellOutput(JSONBlockOutput):
+    confidence: float | None = None 
+
+
+class JSONTableOutput(JSONBlockOutput):
+    table_confidence: float | None = None 
+
+
+JSONBlockOutputType = Union[JSONBlockOutput, JSONTableCellOutput, JSONTableOutput]
 class JSONOutput(BaseModel):
-    children: List[JSONBlockOutput]
+    children: List[JSONBlockOutputType]
     block_type: str = str(BlockTypes.Document)
     metadata: dict
 
@@ -49,36 +58,54 @@ class JSONRenderer(BaseRenderer):
 
     def extract_json(self, document: Document, block_output: BlockOutput):
         cls = get_block_class(block_output.id.block_type)
+         
+        page = document.get_page(block_output.id.page_id)
+        block = page.get_block(block_output.id) if page else None
+        
+        base_fields = {
+            "polygon": block_output.polygon.polygon,
+            "bbox": block_output.polygon.bbox,
+            "id": str(block_output.id),
+            "block_type": str(block_output.id.block_type),
+            "section_hierarchy": reformat_section_hierarchy(block_output.section_hierarchy),
+        }
+
         if cls.__base__ == Block:
             html, images = self.extract_block_html(document, block_output)
-            return JSONBlockOutput(
-                html=html,
-                polygon=block_output.polygon.polygon,
-                bbox=block_output.polygon.bbox,
-                id=str(block_output.id),
-                block_type=str(block_output.id.block_type),
-                images=images,
-                section_hierarchy=reformat_section_hierarchy(
-                    block_output.section_hierarchy
-                ),
-            )
+            if block_output.id.block_type == BlockTypes.TableCell:
+                    confidence = block.confidence if block and hasattr(block, 'confidence') else None
+                    return JSONTableCellOutput(
+                        **base_fields,
+                        html=html,
+                        images=images,
+                        confidence=confidence,
+                    )
+            else:
+                return JSONBlockOutput(
+                    **base_fields,
+                    html=html,
+                    images=images,
+                )
         else:
             children = []
             for child in block_output.children:
                 child_output = self.extract_json(document, child)
                 children.append(child_output)
 
-            return JSONBlockOutput(
-                html=block_output.html,
-                polygon=block_output.polygon.polygon,
-                bbox=block_output.polygon.bbox,
-                id=str(block_output.id),
-                block_type=str(block_output.id.block_type),
-                children=children,
-                section_hierarchy=reformat_section_hierarchy(
-                    block_output.section_hierarchy
-                ),
-            )
+            if block_output.id.block_type in [BlockTypes.Table, BlockTypes.TableOfContents, BlockTypes.Form]:
+                table_confidence = block.table_confidence if block and hasattr(block, 'table_confidence') else None
+                return JSONTableOutput(
+                    **base_fields,
+                    html=block_output.html,
+                    children=children,
+                    table_confidence=table_confidence,
+                )
+            else:
+                return JSONBlockOutput(
+                    **base_fields,
+                    html=block_output.html,
+                    children=children,
+                )
 
     def __call__(self, document: Document) -> JSONOutput:
         document_output = document.render(self.block_config)

--- a/marker/schema/blocks/basetable.py
+++ b/marker/schema/blocks/basetable.py
@@ -8,6 +8,7 @@ from marker.schema.blocks.tablecell import TableCell
 class BaseTable(Block):
     block_type: BlockTypes | None = None
     html: str | None = None
+    table_confidence: float = 0.0
 
     @staticmethod
     def format_cells(

--- a/marker/schema/blocks/tablecell.py
+++ b/marker/schema/blocks/tablecell.py
@@ -12,6 +12,7 @@ class TableCell(Block):
     col_id: int
     is_header: bool
     text_lines: List[str] | None = None
+    confidence: float | None = None
     block_description: str = "A cell in a table."
 
     @property


### PR DESCRIPTION
This PR adds confidence scoring capabilities to the table processing pipeline, enabling both cell-level and table-level confidence metrics to be captured and exposed in the JSON output. This enhancement provides valuable metadata about the quality and reliability of table extraction results.

- Added confidence: float | None = None field to TableCell class. Enables storage of individual cell confidence scores from OCR/text extraction
- Added table_confidence: float = 0.0 field to BaseTable class. Enables storage of aggregated table-level confidence scores Affects all table types: Table, TableOfContents, Form
- Added calculate_table_confidence() method. Calculates average confidence across all cells in a table
- Added calculate_cell_confidence() method. Calculates average confidence for individual table cells
- Updated assign_ocr_lines() method. Preserves confidence data from OCR results: {"text": t, "confidence": cell_text.confidence}
- Added block-specific JSON output classes:
     1. JSONTableCellOutput: Contains only confidence field
     2. JSONTableOutput: Contains only table_confidence field
- Updated extract_json() method. Implements block-specific confidence field inclusion
     TableCell blocks → JSONTableCellOutput with confidence field
     Table blocks → JSONTableOutput with table_confidence field
     Other blocks → JSONBlockOutput with no confidence fields
     
   This feature could be useful when someone is working with surya plus a fallback model, so based on confidence fallback to that model can be implemented. 