### PR TITLE
Add strikethrough support

### DIFF
--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -47,6 +47,7 @@ from marker.schema.blocks import Block
 from marker.schema.registry import register_block_class
 from marker.util import strings_to_classes
 from marker.processors.llm.llm_handwriting import LLMHandwritingProcessor
+from marker.processors.llm.llm_strikethrough import LLMStrikethroughProcessor
 from marker.processors.order import OrderProcessor
 from marker.services.gemini import GoogleGeminiService
 from marker.processors.line_merge import LineMergeProcessor
@@ -94,6 +95,7 @@ class PdfConverter(BaseConverter):
         LLMImageDescriptionProcessor,
         LLMEquationProcessor,
         LLMHandwritingProcessor,
+        LLMStrikethroughProcessor,
         LLMMathBlockProcessor,
         LLMSectionHeaderProcessor,
         LLMPageCorrectionProcessor,

--- a/marker/processors/llm/llm_strikethrough.py
+++ b/marker/processors/llm/llm_strikethrough.py
@@ -1,0 +1,113 @@
+from pydantic import BaseModel
+from marker.processors.llm import PromptData, BaseLLMSimpleBlockProcessor, BlockData
+from marker.schema import BlockTypes
+from marker.schema.document import Document
+from typing import Annotated, List
+
+class LLMStrikethroughProcessor(BaseLLMSimpleBlockProcessor):
+    block_types = (BlockTypes.Text, BlockTypes.ListGroup)
+    min_text_length: Annotated[
+        int,
+        "Minimum text length to consider for strikethrough detection",
+    ] = 3
+
+    strikethrough_detection_prompt = """You're a text correction expert specializing in accurately detecting and reproducing strikethrough text from images.
+You will receive an image and an HTML representation of text. Your task is to detect any strikethrough text in the image and correct the HTML to properly represent it.
+
+Strikethrough text appears with a horizontal line through the middle of the text. This formatting indicates that the text has been deleted, cancelled, or is no longer valid.
+
+# Guidelines:
+- Carefully examine the image for any text that has a line through it
+- Use the <del> HTML tag to mark strikethrough text
+- Keep the text content exactly as it appears, only adding strikethrough markup
+- If no strikethrough text is detected, respond with "No corrections needed."
+
+# Instructions
+1. Carefully examine the provided text block image
+2. Compare it with the HTML representation
+3. Write an analysis of whether any text appears with strikethrough formatting
+4. Set corrections_needed to true if strikethrough text is found, false otherwise
+5. If corrections_needed is true, provide the corrected HTML with <del> tags
+
+# Example
+Input:
+```html
+<p>This price is $100 but now it's $75.</p>
+```
+Output (if $100 has a line through it):
+analysis: The text "$100" appears with a strikethrough line in the image, indicating it's the old price that has been replaced.
+corrections_needed: true
+corrected_html: <p>This price is <del>$100</del> but now it's $75.</p>
+
+# Input
+```html
+{text_html}
+```
+"""
+
+    def inference_blocks(self, document: Document) -> List[BlockData]:
+        blocks = super().inference_blocks(document)
+        out_blocks = []
+        for block_data in blocks:
+            block = block_data["block"]
+            raw_text = block.raw_text(document)
+
+            # Skip blocks that are too short.
+            if len(raw_text.strip()) < self.min_text_length:
+                continue
+
+            out_blocks.append(block_data)
+        return out_blocks
+
+    def block_prompts(self, document: Document) -> List[PromptData]:
+        prompt_data = []
+        for block_data in self.inference_blocks(document):
+            block = block_data["block"]
+            text = block.html if block.html else block.raw_text(document)
+
+            prompt = self.strikethrough_detection_prompt.replace("{text_html}", text)
+            image = self.extract_image(document, block)
+
+            prompt_data.append({
+                "prompt": prompt,
+                "image": image,
+                "block": block,
+                "schema": StrikethroughSchema,
+                "page": block_data["page"]
+            })
+        return prompt_data
+
+    def rewrite_block(self, response: dict, prompt_data: PromptData, document: Document):
+        block = prompt_data["block"]
+
+        if not response:
+            block.update_metadata(llm_error_count=1)
+            return
+
+        # No corrections needed.
+        if not response.get("corrections_needed", False):
+            return
+
+        # Sanity check.
+        corrected_html = response.get("corrected_html")
+        if not corrected_html:
+            block.update_metadata(llm_error_count=1)
+            return
+
+        # Ensure balanced tags.
+        balanced_tags = corrected_html.count("<del") == corrected_html.count("</del>")
+        if not balanced_tags:
+            block.update_metadata(llm_error_count=1)
+            return
+
+        # Ensure the new HTML actually contains strikethrough tags.
+        if "<del>" not in corrected_html:
+            block.update_metadata(llm_error_count=1)
+            return
+
+        block.html = corrected_html
+
+class StrikethroughSchema(BaseModel):
+    analysis: str
+    corrections_needed: bool
+    corrected_html: str

--- a/marker/renderers/markdown.py
+++ b/marker/renderers/markdown.py
@@ -229,6 +229,9 @@ class Markdownify(MarkdownConverter):
         else:
             return text
 
+    def convert_del(self, el, text, parent_tags):
+        return f"~~{text}~~" if text else ""
+
     def escape(self, text, parent_tags=None):
         text = super().escape(text, parent_tags)
         if self.options["escape_dollars"]:

--- a/tests/processors/test_llm_processors.py
+++ b/tests/processors/test_llm_processors.py
@@ -7,6 +7,7 @@ from marker.processors.llm.llm_equation import LLMEquationProcessor
 from marker.processors.llm.llm_form import LLMFormProcessor
 from marker.processors.llm.llm_image_description import LLMImageDescriptionProcessor
 from marker.processors.llm.llm_meta import LLMSimpleBlockMetaProcessor
+from marker.processors.llm.llm_strikethrough import LLMStrikethroughProcessor
 from marker.processors.llm.llm_table import LLMTableProcessor
 from marker.processors.table import TableProcessor
 from marker.renderers.markdown import MarkdownRenderer
@@ -180,3 +181,32 @@ def test_multi_llm_processors(pdf_document):
     contained_equations = pdf_document.contained_blocks((BlockTypes.Equation,))
     print([equation.html for equation in contained_equations])
     assert all(equation.html == description for equation in contained_equations)
+
+@pytest.mark.filename("adversarial.pdf")
+@pytest.mark.config({"page_range": [0]})
+def test_llm_strikethrough_processor(pdf_document):
+    corrected_html = "<p>This is regular text and <del>this text is struck through</del> and this is normal again.</p>"
+    mock_cls = Mock()
+    mock_cls.return_value = {
+        "analysis": "The text 'this text is struck through' has a strikethrough line in the image.",
+        "corrections_needed": True,
+        "corrected_html": corrected_html
+    }
+
+    config = {"use_llm": True, "gemini_api_key": "test"}
+    processor_lst = [LLMStrikethroughProcessor(config)]
+    processor = LLMSimpleBlockMetaProcessor(processor_lst, mock_cls, config)
+    processor(pdf_document)
+
+    text_blocks = pdf_document.contained_blocks((BlockTypes.Text,))
+
+    has_strikethrough = any(
+        block.html and "<del>" in block.html
+        for block in text_blocks
+    )
+    assert has_strikethrough, "No text blocks contain strikethrough HTML"
+
+    renderer = MarkdownRenderer()
+    rendered_md = renderer(pdf_document).markdown
+
+    assert "~~this text is struck through~~" in rendered_md or "<del>" in rendered_md


### PR DESCRIPTION
This adds a simple strikethrough LLM processor that is capable of detecting
strikethrough text. 

Fyi: I wrote tests, but was getting errors related to pulling the
`datalab-to/pdfs` dataset when running the LLM processor suite locally.

Here's a test script with a sample PDF:
[strikethrough.pdf](https://github.com/user-attachments/files/22526512/strikethrough.pdf).

Rendered PDF: https://gist.github.com/aud/2af33313f945a397b28e7ca728a85d8b

```python3
from marker.converters.pdf import PdfConverter
from marker.models import create_model_dict
from marker.config.parser import ConfigParser

config = {
    "output_format": "markdown",
    "use_llm": True,
}

config_parser = ConfigParser(config)

converter = PdfConverter(
    config=config_parser.generate_config_dict(),
    artifact_dict=create_model_dict(),
    processor_list=config_parser.get_processors(),
    renderer=config_parser.get_renderer(),
    llm_service=config_parser.get_llm_service()
)

rendered = converter("strikethrough.pdf")
print(rendered.markdown)
```