### PR TITLE
Update pip install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install marker-pdf
 If you want to use marker on documents other than PDFs, you will need to install additional dependencies with:
 
 ```shell
-pip install marker-pdf[full]
+pip install "marker-pdf[full]"
 ```
 
 # Usage


### PR DESCRIPTION
When square brackets are in pip package, it has to be used in the quotes for it to work. 

So the right command would be

 > `pip install "marker-pdf[full]"`


<img width="1129" height="629" alt="image" src="https://github.com/user-attachments/assets/ba0d877c-ba24-420f-9016-e86b80c64ad9" />
