### PR TITLE
Update gemini service to take list of messages - More flexibility

### DIFF
--- a/marker/services/__init__.py
+++ b/marker/services/__init__.py
@@ -51,5 +51,6 @@ class BaseService:
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        messages: List[PIL.Image.Image | str] | None = None,
     ):
         raise NotImplementedError

--- a/marker/services/azure_openai.py
+++ b/marker/services/azure_openai.py
@@ -48,6 +48,7 @@ class AzureOpenAIService(BaseService):
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        messages: List[PIL.Image.Image | str] | None = None,
     ):
         if max_retries is None:
             max_retries = self.max_retries
@@ -56,17 +57,20 @@ class AzureOpenAIService(BaseService):
             timeout = self.timeout
 
         client = self.get_client()
-        image_data = self.format_image_for_llm(image)
 
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    *image_data,
-                    {"type": "text", "text": prompt},
-                ],
-            }
-        ]
+        if messages is not None:
+            content = [
+                self.format_image_for_llm(msg)[0]
+                if isinstance(msg, PIL.Image.Image)
+                else msg
+                for msg in messages
+            ]
+            content += [{"type": "text", "text": prompt}]
+        else:
+            image_data = self.format_image_for_llm(image)
+            content = image_data + [{"type": "text", "text": prompt}]
+
+        messages = [{"role": "user", "content": content}]
 
         total_tries = max_retries + 1
         for tries in range(1, total_tries + 1):

--- a/marker/services/gemini.py
+++ b/marker/services/gemini.py
@@ -57,10 +57,9 @@ class BaseGeminiService(BaseService):
             timeout = self.timeout
 
         client = self.get_google_client(timeout=timeout)
-        image_parts = self.format_image_for_llm(image)
 
         if messages is not None:
-            gemini_messages = [self.process_images([msg])[0] if isinstance(msg, PIL.Image.Image) else msg for msg in messages]
+            gemini_messages = [self.format_image_for_llm(msg)[0] if isinstance(msg, PIL.Image.Image) else msg for msg in messages]
         else:
             image_parts = self.format_image_for_llm(image)
             # According to gemini docs, it performs better if the image is the first element

--- a/marker/services/ollama.py
+++ b/marker/services/ollama.py
@@ -32,7 +32,10 @@ class OllamaService(BaseService):
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        messages: List[PIL.Image.Image | str] | None = None,
     ):
+        if messages is not None:
+            raise NotImplementedError("OllamaService does not support arbitrary list of messages. Specify `prompt` and `image` instead.")
         url = f"{self.ollama_base_url}/api/generate"
         headers = {"Content-Type": "application/json"}
 

--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -66,6 +66,7 @@ class OpenAIService(BaseService):
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        messages: List[PIL.Image.Image | str] | None = None,
     ):
         if max_retries is None:
             max_retries = self.max_retries
@@ -74,17 +75,18 @@ class OpenAIService(BaseService):
             timeout = self.timeout
 
         client = self.get_client()
-        image_data = self.format_image_for_llm(image)
+        if messages is not None:
+            content = [
+                self.format_image_for_llm(msg)[0]
+                if isinstance(msg, PIL.Image.Image)
+                else msg
+                for msg in messages
+            ]
+        else:
+            image_data = self.format_image_for_llm(image)
+            content = image_data + [{"type": "text", "text": prompt}]
 
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    *image_data,
-                    {"type": "text", "text": prompt},
-                ],
-            }
-        ]
+        messages = [{"role": "user", "content": content}]
 
         total_tries = max_retries + 1
         for tries in range(1, total_tries + 1):


### PR DESCRIPTION
Currently, LLM services only take `prompt: str` and `image: PIL.Image.Image` as input. Need a little bit more flexibility for structured extraction stuff. Enabled by this small change

Doesn't change default usage pattern. 