### PR TITLE
CLI args for  `marker_chunk_convert`

### DIFF
--- a/marker/scripts/chunk_convert.py
+++ b/marker/scripts/chunk_convert.py
@@ -1,20 +1,84 @@
-import argparse
 import os
+import shlex
 import subprocess
-import pkg_resources
+
+import click
+
+from marker.config.parser import ConfigParser
+from marker.config.printer import CustomClickPrinter
 
 
-def chunk_convert_cli():
-    parser = argparse.ArgumentParser(description="Convert a folder of PDFs to a folder of markdown files in chunks.")
-    parser.add_argument("in_folder", help="Input folder with pdfs.")
-    parser.add_argument("out_folder", help="Output folder")
-    args = parser.parse_args()
+def build_cli_args(kwargs):
+    """Convert kwargs dictionary to a list of CLI argument strings."""
+    args = []
+    exclude_params = {
+        "chunk_idx",
+        "num_chunks",
+        "workers",
+        "in_folder",
+        "output_dir",
+    }  # Handled by chunk_convert.sh
 
+    for key, value in kwargs.items():
+        if key in exclude_params or value is None:
+            continue
+
+        if isinstance(value, bool):
+            if value:
+                args.append(f"--{key}")
+        else:
+            args.append(f"--{key}")
+            args.append(str(value))
+
+    return args
+
+
+@click.command(cls=CustomClickPrinter)
+@click.argument("in_folder", type=str)
+@click.option("--chunk_idx", type=int, default=0, help="Chunk index to convert")
+@click.option(
+    "--num_chunks",
+    type=int,
+    default=1,
+    help="Number of chunks being processed in parallel",
+)
+@click.option(
+    "--max_files", type=int, default=None, help="Maximum number of pdfs to convert"
+)
+@click.option(
+    "--skip_existing",
+    is_flag=True,
+    default=False,
+    help="Skip existing converted files.",
+)
+@click.option(
+    "--debug_print", is_flag=True, default=False, help="Print debug information."
+)
+@click.option(
+    "--max_tasks_per_worker",
+    type=int,
+    default=10,
+    help="Maximum number of tasks per worker process before recycling.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Number of worker processes to use.  Set automatically by default, but can be overridden.",
+)
+@ConfigParser.common_options
+def chunk_convert_cli(in_folder: str, **kwargs):
     cur_dir = os.path.dirname(os.path.abspath(__file__))
     script_path = os.path.join(cur_dir, "chunk_convert.sh")
 
+    cli_args = build_cli_args(kwargs)
+
+    # Get output_dir with default fallback
+    output_dir = kwargs.get("output_dir", "")
+
     # Construct the command
-    cmd = f"{script_path} {args.in_folder} {args.out_folder}"
+    escaped_args = " ".join(shlex.quote(arg) for arg in cli_args)
+    cmd = f"{script_path} {shlex.quote(in_folder)} {shlex.quote(output_dir)} {escaped_args}"
 
     # Execute the shell script
     subprocess.run(cmd, shell=True, check=True)

--- a/marker/scripts/chunk_convert.sh
+++ b/marker/scripts/chunk_convert.sh
@@ -26,6 +26,7 @@ fi
 
 INPUT_FOLDER=$1
 OUTPUT_FOLDER=$2
+ADDITIONAL_ARGS=${3:-""}
 
 # Ensure output folder exists
 mkdir -p "$OUTPUT_FOLDER"
@@ -37,7 +38,11 @@ for (( i=0; i<$NUM_DEVICES; i++ )); do
     export NUM_DEVICES
     export NUM_WORKERS
     echo "Running marker on GPU $DEVICE_NUM"
-    cmd="CUDA_VISIBLE_DEVICES=$DEVICE_NUM marker $INPUT_FOLDER --output_dir $OUTPUT_FOLDER --num_chunks $NUM_DEVICES --chunk_idx $DEVICE_NUM --workers $NUM_WORKERS"
+    cmd="CUDA_VISIBLE_DEVICES=$DEVICE_NUM marker $INPUT_FOLDER --output_dir $OUTPUT_FOLDER"
+    if [[ -n "$ADDITIONAL_ARGS" ]]; then
+        cmd="$cmd $ADDITIONAL_ARGS"
+    fi
+    cmd="$cmd --num_chunks $NUM_DEVICES --chunk_idx $DEVICE_NUM --workers $NUM_WORKERS"
     eval $cmd &
 
     sleep 5


### PR DESCRIPTION
Fixes #527

Updated `chunk_convert_cli()` to accept all the same parameters as `convert_cli()` by replacing `argparse` with `click` decorators and forwarding arguments through the bash script. The `build_cli_args()` helper converts kwargs to CLI argument strings, excluding only device-specific parameters (`chunk_idx`, `num_chunks`, `workers`) which are handled per-device by `chunk_convert.sh`. All other options (e.g., `--skip_existing`, `--debug`, `--output_format`, `--max_files`) are now supported.