### PR TITLE
fix bugs, improve LLM Schemas and LLM Processors

### DIFF
--- a/marker/processors/llm/__init__.py
+++ b/marker/processors/llm/__init__.py
@@ -24,7 +24,7 @@ class PromptData(TypedDict):
     prompt: str
     image: Image.Image
     block: Block
-    schema: BaseModel
+    schema: type[BaseModel]
     page: PageGroup
     additional_data: dict | None
 

--- a/marker/processors/llm/llm_form.py
+++ b/marker/processors/llm/llm_form.py
@@ -1,3 +1,4 @@
+import re
 from typing import List
 
 from pydantic import BaseModel
@@ -7,6 +8,34 @@ from marker.processors.llm import PromptData, BaseLLMSimpleBlockProcessor, Block
 
 from marker.schema import BlockTypes
 from marker.schema.document import Document
+
+
+_NO_CORRECTION_PHRASES = (
+    "no_corrections",
+    "no corrections",
+    "no corrections needed",
+    "no correction needed",
+    "no correction required",
+    "no corrections required",
+    "no errors detected",
+    "no errors found",
+    "no changes needed",
+    "no change needed",
+    "looks good",
+)
+
+
+def _strip_code_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text)
+    return text.strip()
+
+
+def _string_indicates_no_corrections(text: str) -> bool:
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in _NO_CORRECTION_PHRASES)
 
 
 class LLMFormProcessor(BaseLLMSimpleBlockProcessor):
@@ -19,9 +48,12 @@ Values and labels should appear in html tables, with the labels on the left side
 1. Carefully examine the provided form block image.
 2. Analyze the html representation of the form.
 3. Compare the html representation to the image.
-4. If the html representation is correct, or you cannot read the image properly, then write "No corrections needed."
-5. If the html representation contains errors, generate the corrected html representation.
-6. Output only either the corrected html representation or "No corrections needed."
+4. Output a single JSON object (and only JSON) matching this schema:
+    - `comparison`: short string
+    - `correction_needed`: boolean
+    - `corrected_html`: corrected HTML string (empty when `correction_needed` is false)
+5. If the html representation is correct, or you cannot read the image properly, set `correction_needed` to false and `corrected_html` to "".
+6. If the html representation contains errors, set `correction_needed` to true and provide the corrected HTML in `corrected_html`.
 **Example:**
 Input:
 ```html
@@ -39,22 +71,25 @@ Input:
 </table> 
 ```
 Output:
-Comparison: The html representation has the labels in the first row and the values in the second row.  It should be corrected to have the labels on the left side and the values on the right side.
-```html
-<table>
-    <tr>
-        <td>Label 1</td>
-        <td>Value 1</td>
-    </tr>
-    <tr>
-        <td>Label 2</td>
-        <td>Value 2</td>
-    </tr>
-    <tr>
-        <td>Label 3</td>
-        <td>Value 3</td>
-    </tr>
-</table>
+```json
+{
+  "comparison": "The html representation has the labels in the first row and the values in the second row. It should be corrected to have the labels on the left side and the values on the right side.",
+  "correction_needed": true,
+  "corrected_html": "<table>
+<tr>
+    <td>Label 1</td>
+    <td>Value 1</td>
+</tr>
+<tr>
+    <td>Label 2</td>
+    <td>Value 2</td>
+</tr>
+<tr>
+    <td>Label 3</td>
+    <td>Value 3</td>
+</tr>
+</table>"
+}
 ```
 **Input:**
 ```html
@@ -73,7 +108,6 @@ Comparison: The html representation has the labels in the first row and the valu
             out_blocks.append(block_data)
         return out_blocks
 
-
     def block_prompts(self, document: Document) -> List[PromptData]:
         prompt_data = []
         for block_data in self.inference_blocks(document):
@@ -81,38 +115,56 @@ Comparison: The html representation has the labels in the first row and the valu
             block_html = json_to_html(block.render(document))
             prompt = self.form_rewriting_prompt.replace("{block_html}", block_html)
             image = self.extract_image(document, block)
-            prompt_data.append({
-                "prompt": prompt,
-                "image": image,
-                "block": block,
-                "schema": FormSchema,
-                "page": block_data["page"]
-            })
+            prompt_data.append(
+                {
+                    "prompt": prompt,
+                    "image": image,
+                    "block": block,
+                    "schema": FormSchema,
+                    "page": block_data["page"],
+                }
+            )
         return prompt_data
 
-
-    def rewrite_block(self, response: dict, prompt_data: PromptData, document: Document):
+    def rewrite_block(
+        self, response: dict, prompt_data: PromptData, document: Document
+    ):
         block = prompt_data["block"]
         block_html = json_to_html(block.render(document))
 
-        if not response or "corrected_html" not in response:
+        if not response:
             block.update_metadata(llm_error_count=1)
             return
 
-        corrected_html = response["corrected_html"]
+        correction_needed = response.get("correction_needed", None)
+        corrected_html = response.get("corrected_html", "") or ""
+
+        # specifically checking for False
+        if correction_needed is False:
+            return
+
+        # Fallback if LLM did not adhere to schema but used phases like: "No corrections needed."
+        if _string_indicates_no_corrections(corrected_html):
+            return
+
+        if not corrected_html:
+            block.update_metadata(llm_error_count=1)
+            return
 
         # The original table is okay
-        if "no corrections needed" in corrected_html.lower():
+        if _string_indicates_no_corrections(corrected_html):
             return
 
         # Potentially a partial response
-        if len(corrected_html) < len(block_html) * .33:
+        if len(corrected_html) < len(block_html) * 0.33:
             block.update_metadata(llm_error_count=1)
             return
 
-        corrected_html = corrected_html.strip().lstrip("```html").rstrip("```").strip()
+        corrected_html = _strip_code_fences(corrected_html)
         block.html = corrected_html
 
+
 class FormSchema(BaseModel):
-    comparison: str
-    corrected_html: str
+    comparison: str = ""
+    correction_needed: bool = False
+    corrected_html: str = ""

--- a/marker/processors/llm/llm_form.py
+++ b/marker/processors/llm/llm_form.py
@@ -75,20 +75,7 @@ Output:
 {
   "comparison": "The html representation has the labels in the first row and the values in the second row. It should be corrected to have the labels on the left side and the values on the right side.",
   "correction_needed": true,
-  "corrected_html": "<table>
-<tr>
-    <td>Label 1</td>
-    <td>Value 1</td>
-</tr>
-<tr>
-    <td>Label 2</td>
-    <td>Value 2</td>
-</tr>
-<tr>
-    <td>Label 3</td>
-    <td>Value 3</td>
-</tr>
-</table>"
+  "corrected_html": "<table><tr><td>Label 1</td><td>Value 1</td></tr><tr><td>Label 2</td><td>Value 2</td></tr><tr><td>Label 3</td><td>Value 3</td></tr></table>"
 }
 ```
 **Input:**

--- a/marker/processors/llm/llm_form.py
+++ b/marker/processors/llm/llm_form.py
@@ -1,41 +1,16 @@
-import re
 from typing import List
 
 from pydantic import BaseModel
 
 from marker.output import json_to_html
 from marker.processors.llm import PromptData, BaseLLMSimpleBlockProcessor, BlockData
+from marker.processors.llm.llm_utils import (
+    strip_code_fences,
+    string_indicates_no_corrections,
+)
 
 from marker.schema import BlockTypes
 from marker.schema.document import Document
-
-
-_NO_CORRECTION_PHRASES = (
-    "no_corrections",
-    "no corrections",
-    "no corrections needed",
-    "no correction needed",
-    "no correction required",
-    "no corrections required",
-    "no errors detected",
-    "no errors found",
-    "no changes needed",
-    "no change needed",
-    "looks good",
-)
-
-
-def _strip_code_fences(text: str) -> str:
-    text = text.strip()
-    if text.startswith("```"):
-        text = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", text)
-        text = re.sub(r"\n?```$", "", text)
-    return text.strip()
-
-
-def _string_indicates_no_corrections(text: str) -> bool:
-    lowered = text.lower()
-    return any(phrase in lowered for phrase in _NO_CORRECTION_PHRASES)
 
 
 class LLMFormProcessor(BaseLLMSimpleBlockProcessor):
@@ -131,7 +106,7 @@ Output:
             return
 
         # Fallback if LLM did not adhere to schema but used phases like: "No corrections needed."
-        if _string_indicates_no_corrections(corrected_html):
+        if string_indicates_no_corrections(corrected_html):
             return
 
         if not corrected_html:
@@ -139,7 +114,7 @@ Output:
             return
 
         # The original table is okay
-        if _string_indicates_no_corrections(corrected_html):
+        if string_indicates_no_corrections(corrected_html):
             return
 
         # Potentially a partial response
@@ -147,7 +122,7 @@ Output:
             block.update_metadata(llm_error_count=1)
             return
 
-        corrected_html = _strip_code_fences(corrected_html)
+        corrected_html = strip_code_fences(corrected_html)
         block.html = corrected_html
 
 

--- a/marker/processors/llm/llm_mathblock.py
+++ b/marker/processors/llm/llm_mathblock.py
@@ -96,9 +96,12 @@ with parameters w, the optimization objective of AT can be formulated as follows
 ```
 
 Output:
-analysis: The inline math is not in LaTeX format and is not surrounded by <math>...</math> tags.
-```html
-Adversarial training <i>(AT)</i> <a href='#page-9-1'>[23]</a>, which aims to minimize the model's risk under the worst-case perturbations, is currently the most effective approach for improving the robustness of deep neural networks. For a given neural network <math>f(x, w)</math> with parameters <math>w</math>, the optimization objective of AT can be formulated as follows:
+```json
+{
+  "analysis": "The inline math is not in LaTeX format and is not surrounded by <math>...</math> tags.",
+  "correction_needed": true,
+  "corrected_html": "Adversarial training <i>(AT)</i> <a href='#page-9-1'>[23]</a>, which aims to minimize the model's risk under the worst-case perturbations, is currently the most effective approach for improving the robustness of deep neural networks. For a given neural network <math>f(x, w)</math> with parameters <math>w</math>, the optimization objective of AT can be formulated as follows:"
+}
 ```
 
 **Input:**

--- a/marker/processors/llm/llm_meta.py
+++ b/marker/processors/llm/llm_meta.py
@@ -1,10 +1,10 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Dict, Any
+from typing import List
 
 from marker.logger import get_logger
 from tqdm import tqdm
 
-from marker.processors.llm import BaseLLMSimpleBlockProcessor, BaseLLMProcessor
+from marker.processors.llm import BaseLLMSimpleBlockProcessor, BaseLLMProcessor, PromptData
 from marker.schema.document import Document
 from marker.services import BaseService
 from marker.telemetry import build_marker_trace_headers
@@ -72,7 +72,10 @@ class LLMSimpleBlockMetaProcessor(BaseLLMProcessor):
 
         pbar.close()
 
-    def get_response(self, prompt_data: Dict[str, Any]):
+    def get_response(self, prompt_data: PromptData):
+        if self.llm_service is None:
+            raise ValueError("LLM service is not configured")
+
         additional = prompt_data.get("additional_data") or {}
         headers = build_marker_trace_headers(
             source_path=additional.get("marker_source_path"),

--- a/marker/processors/llm/llm_meta.py
+++ b/marker/processors/llm/llm_meta.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 from marker.processors.llm import BaseLLMSimpleBlockProcessor, BaseLLMProcessor
 from marker.schema.document import Document
 from marker.services import BaseService
+from marker.telemetry import build_marker_trace_headers
 
 logger = get_logger()
 
@@ -39,6 +40,13 @@ class LLMSimpleBlockMetaProcessor(BaseLLMProcessor):
         all_prompts = [
             processor.block_prompts(document) for processor in self.processors
         ]
+        for processor, prompt_lst in zip(self.processors, all_prompts):
+            for prompt in prompt_lst:
+                additional = prompt.get("additional_data") or {}
+                additional.setdefault("marker_processor", processor.__class__.__name__)
+                additional.setdefault("marker_source_path", document.filepath)
+                prompt["additional_data"] = additional
+
         pending = []
         futures_map = {}
         with ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
@@ -65,9 +73,17 @@ class LLMSimpleBlockMetaProcessor(BaseLLMProcessor):
         pbar.close()
 
     def get_response(self, prompt_data: Dict[str, Any]):
+        additional = prompt_data.get("additional_data") or {}
+        headers = build_marker_trace_headers(
+            source_path=additional.get("marker_source_path"),
+            processor=additional.get("marker_processor"),
+            block_id=str(prompt_data["block"].id) if prompt_data.get("block") else None,
+            page_id=getattr(prompt_data.get("page"), "page_id", None),
+        )
         return self.llm_service(
             prompt_data["prompt"],
             prompt_data["image"],
             prompt_data["block"],
             prompt_data["schema"],
+            extra_headers=headers,
         )

--- a/marker/processors/llm/llm_page_correction.py
+++ b/marker/processors/llm/llm_page_correction.py
@@ -143,11 +143,14 @@ User Prompt
         selected_blocks = page.structure_blocks(document)
         json_blocks = [
             self.normalize_block_json(block, document, page)
-            for i, block in enumerate(selected_blocks)
+            for block in selected_blocks
         ]
         return json_blocks
 
     def process_rewriting(self, document: Document, page1: PageGroup):
+        if self.llm_service is None:
+            raise ValueError("LLM service is not configured")
+
         page_blocks = self.get_selected_blocks(document, page1)
         image = page1.get_image(document, highres=False)
 

--- a/marker/processors/llm/llm_page_correction.py
+++ b/marker/processors/llm/llm_page_correction.py
@@ -1,6 +1,8 @@
 import json
+import re
+from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Annotated
+from typing import List, Annotated, Literal, cast
 
 from marker.logger import get_logger
 from marker.processors.llm import BaseLLMComplexBlockProcessor
@@ -8,10 +10,68 @@ from marker.schema import BlockTypes
 from marker.schema.blocks import BlockId
 from marker.schema.document import Document
 from marker.schema.groups import PageGroup
-from pydantic import BaseModel
+from marker.telemetry import build_marker_trace_headers
+from pydantic import BaseModel, Field
 from tqdm import tqdm
 
 logger = get_logger()
+
+CorrectionType = Literal["reorder", "rewrite", "reorder_first"]
+
+_NO_CORRECTION_PHRASES = (
+    "no_corrections",
+    "no corrections",
+    "no correction required",
+    "no corrections required",
+    "no errors detected",
+    "no errors found",
+    "no changes needed",
+    "no change needed",
+    "looks good",
+)
+
+
+def _strip_code_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text)
+    return text.strip()
+
+
+def _string_indicates_no_corrections(text: str) -> bool:
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in _NO_CORRECTION_PHRASES)
+
+
+def _normalize_correction_type(value: str | None) -> CorrectionType | None:
+    if not value:
+        return None
+    lowered = value.strip().lower()
+    lowered = lowered.replace("-", "_").replace(" ", "_")
+    if lowered in ("reorder", "rewrite", "reorder_first"):
+        return cast(CorrectionType, lowered)
+    return None
+
+
+def _parse_block_id_parts(block_id: str) -> tuple[str, str, str] | None:
+    parts = block_id.strip().lstrip("/").split("/")
+    # if block_id starts with "/page/", see schema.blocks.base.BlockId class
+    if len(parts) == 4 and parts[0] == "page":
+        _, page_id, block_type, block_num = parts
+        return page_id, block_type, block_num
+    if len(parts) == 3:
+        page_id, block_type, block_num = parts
+        return page_id, block_type, block_num
+    return None
+
+
+@dataclass(frozen=True)
+class _NormalizedPageCorrectionResponse:
+    correction_needed: bool
+    correction_type: CorrectionType | None
+    blocks: list
+
 
 FORMAT_TAGS = ["b", "i", "u", "del", "math", "sub", "sup", "a", "code", "p", "img"]
 BLOCK_MAP = {
@@ -31,7 +91,8 @@ ALL_TAGS = FORMAT_TAGS + [tag for tags in BLOCK_MAP.values() for tag in tags]
 
 class LLMPageCorrectionProcessor(BaseLLMComplexBlockProcessor):
     block_correction_prompt: Annotated[
-        str | None, "The user prompt to guide the block correction process. If None, will use `default_user_prompt`."
+        str | None,
+        "The user prompt to guide the block correction process. If None, will use `default_user_prompt`.",
     ] = None
     default_user_prompt = """Your goal is to reformat the blocks to be as correct as possible, without changing the underlying meaning of the text within the blocks.  Mostly focus on reformatting the content.  Ignore minor formatting issues like extra <i> tags."""
     page_prompt = """You're a text correction expert specializing in accurately reproducing text from PDF pages. You will be given a JSON list of blocks on a PDF page, along with the image for that page.  The blocks will be formatted like the example below.  The blocks will be presented in reading order.
@@ -51,9 +112,9 @@ You will also be given a prompt from the user that tells you how to correct the 
 
 Here are the types of changes you can make in response to the prompt:
 
-- Reorder the blocks to reflect the correct reading order.
-- Change the block type to the correct type - the potential types are "SectionHeader", "Form", "Text", "Table", "Figure", "Picture", "ListGroup", "PageFooter", "PageHeader", "Footnote", or "Equation".  In this case, update the html as well to match the new block type.
-- Make edits to block content by changing the HTML.
+- ("reorder") Reorder the blocks to reflect the correct reading order.
+- ("rewrite") Change the block type to the correct type - the potential types are "SectionHeader", "Form", "Text", "Table", "Figure", "Picture", "ListGroup", "PageFooter", "PageHeader", "Footnote", or "Equation".  In this case, update the html as well to match the new block type.
+- ("rewrite") Make edits to block content by changing the HTML.
 
 Guidelines:
 - Only use the following tags: {{format_tags}}.  Do not use any other tags.  
@@ -68,8 +129,13 @@ Guidelines:
 1. Carefully examine the provided JSON representation of the page, along with the image.
 2. Analyze the user prompt.
 3. Identify any issues you'll need to fix, and write a short analysis.
-4. If everything is fine, output "no_corrections"  Otherwise, output the type of correction needed: ["reorder", "rewrite", "reorder_first"].  Rewrite includes rewriting html and changing the block type.  If you need to do both, then perform only the reordering, and output "reorder_first", so we can do the rewriting later.
-5. If corrections are needed, output any blocks that need updates:
+4. Output a single JSON object (and only JSON) matching this schema:
+    - `analysis`: short string
+    - `correction_needed`: boolean
+    - `correction_type`: one of ["reorder", "rewrite", "reorder_first", None] (omit or set null when `correction_needed` is false). "rewrite" includes rewriting html and changing the block type. If you need to do both "rewrite" and "reorder", then perform only the reordering, and output "reorder_first", so we can do the rewriting later.
+    - `blocks`: array of objects with `id`, `block_type`, and `html` (only include the blocks that need updates)
+5. If `correction_needed` is false, set `blocks` to an empty array.
+6. If `correction_needed` is true, output any blocks that need updates:
     a. If reading order needs to be changed, output the IDs of the blocks in the correct order, and keep block_type and html blank, like this:
     ```json
     [
@@ -115,15 +181,19 @@ Blocks
 User Prompt
 Ensure that all blocks have the correct labels, and that reading order is correct.
 Output:
-Analysis: The blocks are in the correct reading order, but the first block should actually be a SectionHeader.
 ```json
-[
+{
+  "analysis": "The blocks are in the correct reading order, but the first block should actually be a SectionHeader.",
+  "correction_needed": true,
+  "correction_type": "rewrite",
+  "blocks": [
     {
-        "id": "/page/0/Text/1",
-        "block_type": "SectionHeader",
-        "html": "<h1>1.14 Vector Operations</h1>"
+      "id": "/page/0/Text/1",
+      "block_type": "SectionHeader",
+      "html": "<h1>1.14 Vector Operations</h1>"
     }
-]
+  ]
+}
 ```
 
 **Input:**
@@ -157,95 +227,166 @@ User Prompt
         prompt = (
             self.page_prompt.replace("{{page_json}}", json.dumps(page_blocks))
             .replace("{{format_tags}}", json.dumps(ALL_TAGS))
-            .replace("{{user_prompt}}", self.block_correction_prompt or self.default_user_prompt)
+            .replace(
+                "{{user_prompt}}",
+                self.block_correction_prompt or self.default_user_prompt,
+            )
         )
-        response = self.llm_service(prompt, image, page1, PageSchema)
+        headers = build_marker_trace_headers(
+            source_path=document.filepath,
+            processor=self.__class__.__name__,
+            block_id=str(page1.id),
+            page_id=page1.page_id,
+        )
+        response = self.llm_service(
+            prompt, image, page1, PageSchema, extra_headers=headers
+        )
         logger.debug(f"Got reponse from LLM: {response}")
 
-        if not response or "correction_type" not in response:
+        normalized = self._normalize_response(response)
+        if normalized is None:
             logger.warning("LLM did not return a valid response")
             return
 
-        correction_type = response["correction_type"]
-        if correction_type == "no_corrections":
+        if not normalized.correction_needed:
             return
-        elif correction_type in ["reorder", "reorder_first"]:
-            self.load_blocks(response)
-            self.handle_reorder(response["blocks"], page1)
 
-            # If we needed to reorder first, we will handle the rewriting next
+        if not normalized.blocks:
+            return
+
+        correction_type = normalized.correction_type
+        if correction_type is None:
+            correction_type = self._infer_correction_type_from_blocks(normalized.blocks)
+            if correction_type is None:
+                logger.warning("Unable to determine correction type from LLM response")
+                return
+
+        if correction_type in ["reorder", "reorder_first"]:
+            self.handle_reorder(normalized.blocks, page1)
+
             if correction_type == "reorder_first":
                 self.process_rewriting(document, page1)
         elif correction_type == "rewrite":
-            self.load_blocks(response)
-            self.handle_rewrites(response["blocks"], document)
+            self.handle_rewrites(normalized.blocks, document)
         else:
             logger.warning(f"Unknown correction type: {correction_type}")
             return
 
-    def load_blocks(self, response):
-        if isinstance(response["blocks"], str):
-            response["blocks"] = json.loads(response["blocks"])
+    def _normalize_response(self, response) -> _NormalizedPageCorrectionResponse | None:
+        if response is None:
+            return None
+
+        if isinstance(response, str):
+            text = _strip_code_fences(response)
+            if _string_indicates_no_corrections(text):
+                return _NormalizedPageCorrectionResponse(
+                    correction_needed=False, correction_type=None, blocks=[]
+                )
+            try:
+                response = json.loads(text)
+            except Exception:
+                return None
+
+        if isinstance(response, list):
+            correction_type = self._infer_correction_type_from_blocks(response)
+            return _NormalizedPageCorrectionResponse(
+                correction_needed=len(response) > 0,
+                correction_type=correction_type,
+                blocks=response,
+            )
+
+        if not isinstance(response, dict):
+            return None
+
+        blocks = response.get("blocks", [])
+        if isinstance(blocks, str):
+            try:
+                blocks = json.loads(_strip_code_fences(blocks))
+            except Exception:
+                blocks = []
+
+        correction_needed = response.get("correction_needed", None)
+        correction_type = _normalize_correction_type(
+            response.get("correction_type", None)
+        )
+        if correction_needed is None:
+            raw_type = str(response.get("correction_type", "") or "")
+            if _string_indicates_no_corrections(raw_type):
+                correction_needed = False
+            else:
+                correction_needed = bool(correction_type) or bool(blocks)
+
+        if not bool(correction_needed):
+            correction_type = None
+            blocks = []
+
+        return _NormalizedPageCorrectionResponse(
+            correction_needed=bool(correction_needed),
+            correction_type=correction_type,
+            blocks=blocks if isinstance(blocks, list) else [],
+        )
+
+    def _infer_correction_type_from_blocks(self, blocks: list) -> CorrectionType | None:
+        if not isinstance(blocks, list) or not blocks:
+            return None
+
+        # Reorder responses are a list of IDs with empty block_type/html.
+        is_reorder = True
+        for block in blocks:
+            if not isinstance(block, dict):
+                is_reorder = False
+                break
+            if (block.get("block_type") or "").strip() or (
+                block.get("html") or ""
+            ).strip():
+                is_reorder = False
+                break
+
+        if is_reorder:
+            return "reorder"
+
+        return "rewrite"
 
     def handle_reorder(self, blocks: list, page1: PageGroup):
-        unique_page_ids = set()
-        document_page_ids = [str(page1.page_id)]
-        document_pages = [page1]
+        expected_page_id = str(page1.page_id)
+        parsed_ids: list[BlockId] = []
+        response_page_ids: set[str] = set()
 
         for block_data in blocks:
             try:
-                page_id, _, _ = block_data["id"].split("/")
-                unique_page_ids.add(page_id)
+                parts = _parse_block_id_parts(block_data["id"])
+                if parts is None:
+                    continue
+                page_id, block_type, block_num = parts
+                response_page_ids.add(str(page_id))
+                parsed_ids.append(
+                    # NOTE: not sure if doing int() may break
+                    BlockId(
+                        page_id=int(page_id),
+                        block_id=int(block_num),
+                        block_type=getattr(BlockTypes, block_type),
+                    )
+                )
             except Exception as e:
-                logger.debug(f"Error parsing block ID {block_data['id']}: {e}")
+                logger.debug(f"Error parsing block ID {block_data.get('id')}: {e}")
                 continue
 
-        if set(document_page_ids) != unique_page_ids:
+        if response_page_ids != {expected_page_id}:
             logger.debug(
-                "Some page IDs in the response do not match the document's pages"
+                "Some page IDs in the response do not match the document's page"
             )
             return
 
-        for page_id, document_page in zip(unique_page_ids, document_pages):
-            block_ids_for_page = []
-            for block_data in blocks:
-                try:
-                    page_id, block_type, block_id = block_data["id"].split("/")
-                    block_id = BlockId(
-                        page_id=page_id,
-                        block_id=block_id,
-                        block_type=getattr(BlockTypes, block_type),
-                    )
-                    block_ids_for_page.append(block_id)
-                except Exception as e:
-                    logger.debug(f"Error parsing block ID {block_data['id']}: {e}")
-                    continue
+        if not parsed_ids:
+            return
 
-                # Both sides should have the same values, just be reordered
-                if not all(
-                    [
-                        block_id in document_page.structure
-                        for block_id in block_ids_for_page
-                    ]
-                ):
-                    logger.debug(
-                        f"Some blocks for page {page_id} not found in document"
-                    )
-                    continue
+        if set(parsed_ids) != set(page1.structure or []):
+            logger.debug(
+                "Reorder response does not contain the same blocks as the page"
+            )
+            return
 
-                if not all(
-                    [
-                        block_id in block_ids_for_page
-                        for block_id in document_page.structure
-                    ]
-                ):
-                    logger.debug(
-                        f"Some blocks in document page {page_id} not found in response"
-                    )
-                    continue
-
-                # Swap the order of blocks in the document page
-                document_page.structure = block_ids_for_page
+        page1.structure = parsed_ids
 
     def handle_rewrites(self, blocks: list, document: Document):
         for block_data in blocks:
@@ -300,6 +441,7 @@ class BlockSchema(BaseModel):
 
 
 class PageSchema(BaseModel):
-    analysis: str
-    correction_type: str
-    blocks: List[BlockSchema]
+    analysis: str = ""
+    correction_needed: bool = False
+    correction_type: CorrectionType | None = None
+    blocks: List[BlockSchema] = Field(default_factory=list)

--- a/marker/processors/llm/llm_page_correction.py
+++ b/marker/processors/llm/llm_page_correction.py
@@ -70,7 +70,7 @@ ALL_TAGS = FORMAT_TAGS + [tag for tags in BLOCK_MAP.values() for tag in tags]
 class LLMPageCorrectionProcessor(BaseLLMComplexBlockProcessor):
     analysis_style: Annotated[
         str,
-        "How to structure the LLM analysis field: 'summary' or 'auto'.",
+        "How to structure the LLM analysis field: 'summary', 'deep' or 'auto'.",
     ] = "summary"
     block_correction_prompt: Annotated[
         str | None,

--- a/marker/processors/llm/llm_sectionheader.py
+++ b/marker/processors/llm/llm_sectionheader.py
@@ -1,8 +1,12 @@
 import json
+import re
+from functools import lru_cache
+from html import unescape
 from dataclasses import dataclass
 from typing import List, Tuple, Annotated
 
 from tqdm import tqdm
+from transformers import AutoTokenizer
 
 from marker.logger import get_logger
 from marker.processors.llm import BaseLLMComplexBlockProcessor
@@ -31,8 +35,42 @@ class _NormalizedSectionHeaderResponse:
 class LLMSectionHeaderProcessor(BaseLLMComplexBlockProcessor):
     analysis_style: Annotated[
         str,
-        "How to structure the LLM analysis field: 'summary' or 'auto'.",
+        "How to structure the LLM analysis field: 'summary', 'deep' or 'auto'. "
+        "'summary' is brief, 'deep' is more detailed, 'auto' lets the LLM decide."
+        "'deep' is HIGHLY recommended for best results, at the expense of more tokens and e2e latency.",
     ] = "summary"
+    max_rewrite_retries: Annotated[
+        int,
+        "How many times to retry section header correction when confidence is low. "
+        "Increase this to improve results at the cost of more LLM calls. "
+        "Defaults to 0 to preserve existing marker behavior.",
+    ] = 0
+    max_chunk_tokens: Annotated[
+        int,
+        "Max prompt tokens per chunk (0 disables chunking). "
+        "Highly recommended to enable chunking for large documents. "
+        "Defaults to 0 to preserve marker's existing behavior.",
+    ] = 0
+    chunk_tokenizer_hf_model_id: Annotated[
+        str,
+        "HuggingFace tokenizer model id used for chunking token counts (best-effort).",
+    ] = ""
+    neighbor_text_max_blocks: Annotated[
+        int,
+        "Max number of neighboring text blocks to include before/after each header. "
+        "Recommended to try 1-2 along with chunking (`max_chunk_tokens`) for better context. "
+        "Defaults to 0 to preserve existing marker behavior.",
+    ] = 0
+    neighbor_text_max_chars: Annotated[
+        int,
+        "Max chars of neighboring text to include per side (before/after).",
+    ] = 250
+    recent_headers_max_count: Annotated[
+        int,
+        "How many recently-processed headers to include as context for later chunks. "
+        "If no chunking is used (`max_chunk_tokens == 0`), this has no effect. "
+        "Defaults to 0 to preserve existing marker behavior.",
+    ] = 0
     page_prompt = """You're a text correction expert specializing in accurately analyzing complex PDF documents. You will be given a list of all of the section headers from a document, along with their page number and approximate dimensions.  The headers will be formatted like below, and will be presented in order.
 
 ```json
@@ -41,6 +79,9 @@ class LLMSectionHeaderProcessor(BaseLLMComplexBlockProcessor):
         "bbox": [x1, y1, x2, y2],
         "width": x2 - x1,
         "height": y2 - y1,
+        "line_height": 12.5,
+        "prev_text": "…",
+        "next_text": "…",
         "page": 0,
         "id": "/page/0/SectionHeader/1",
         "html": "<h1>Introduction</h1>",
@@ -57,6 +98,14 @@ Guidelines:
 - Only edit the h1, h2, h3, h4, h5, and h6 tags.  Do not change any other tags or content in the headers.
 - Only include the headers that changed in the `blocks` array (if nothing changed, set `correction_needed` to false and `blocks` to []).
 - Every header you output needs to have one and only one level tag (h1, h2, h3, h4, h5, or h6).
+- Use layout cues to infer hierarchy: larger `height`/`line_height` and smaller left indent (`bbox[0]`) indicate higher-level headings.
+- Headings with similar `line_height`/`height` and left indent are peers; assign them the same h-level even if their current tags differ.
+- Avoid skipping levels (e.g., h2 -> h4). Keep nesting consistent across the document.
+
+Notes:
+- Additional fields such as `line_height`, `line_height_norm`, or `left` may be provided; use them when available.
+- `prev_text` and `next_text` will be provided and represent nearby document content; you must pay attention to them to 
+    disambiguate header depth. This is especially important as the section headers themselves may come with a lot of errors.
 
 **Instructions:**
 1. Carefully examine the provided section headers and JSON.
@@ -68,6 +117,7 @@ Guidelines:
     - `score`: integer 1-5 indicating confidence in the corrected header levels (5 = fully confident)
         IMPORTANT: you must output `score` last, only after writing ALL the blocks.
 4. If `correction_needed` is false, set `blocks` to an empty array.
+5. Only correct the headers in the "Section Headers" JSON. Use "Recent Headers" for context only.
 
 **Example:**
 Input:
@@ -102,16 +152,179 @@ Output:
       "id": "/page/0/SectionHeader/2",
       "html": "<h2>1.1 Vector Addition</h2>"
     }
-  ]
+  ],
+  "score": 4
 }
 ```
 
 **Input:**
+Recent Headers (already processed; for context only)
+```json
+{{recent_headers_json}}
+```
+
 Section Headers
 ```json
 {{section_header_json}}
 ```
 """
+
+    @staticmethod
+    def _round_1dp(value: float) -> float:
+        return round(float(value), 1)
+
+    @staticmethod
+    def _extract_h_level(html: str) -> int | None:
+        match = re.search(r"<h([1-6])\\b", html or "", flags=re.IGNORECASE)
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except Exception:  # noqa: BLE001 - best effort
+            return None
+
+    @staticmethod
+    def _html_to_compact_text(html: str) -> str:
+        text = re.sub(r"<[^>]+>", " ", html or "")
+        text = unescape(text)
+        text = re.sub(r"\\s+", " ", text).strip()
+        return text
+
+    @staticmethod
+    @lru_cache(maxsize=8)
+    def _load_tokenizer(hf_model_id: str):
+        return AutoTokenizer.from_pretrained(
+            hf_model_id, use_fast=True, trust_remote_code=True
+        )
+
+    def _get_tokenizer(self):
+        candidates = [self.chunk_tokenizer_hf_model_id.strip()] if self.chunk_tokenizer_hf_model_id else []
+        candidates.extend(
+            [
+                "Qwen/Qwen3-8B",
+                "Qwen/Qwen2.5-7B-Instruct",
+            ]
+        )
+        for model_id in [c for c in candidates if c]:
+            try:
+                return self._load_tokenizer(model_id)
+            except Exception as exc:  # noqa: BLE001 - best effort
+                logger.warning(
+                    "Unable to load tokenizer %s for chunking: %s", model_id, exc
+                )
+        return None
+
+    def _count_prompt_tokens(self, text: str) -> int:
+        tokenizer = self._get_tokenizer()
+        if tokenizer is None:
+            return len(text) // 4
+        try:
+            return len(tokenizer.encode(text, add_special_tokens=False))
+        except Exception:  # noqa: BLE001 - best effort
+            return len(text) // 4
+
+    def _page_structure_index(self, page: PageGroup) -> dict[str, int]:
+        structure = page.structure or []
+        return {str(block_id): idx for idx, block_id in enumerate(structure)}
+
+    def _get_neighbor_text(
+        self,
+        document: Document,
+        page: PageGroup,
+        block: Block,
+        *,
+        direction: int,
+        page_index: dict[str, int],
+    ) -> str:
+        if self.neighbor_text_max_blocks <= 0 or self.neighbor_text_max_chars <= 0:
+            return ""
+        structure = page.structure or []
+        pos = page_index.get(str(block.id))
+        if pos is None:
+            return ""
+
+        collected: list[str] = []
+        i = pos + direction
+        while (
+            0 <= i < len(structure)
+            and len(collected) < self.neighbor_text_max_blocks
+        ):
+            neighbor = page.get_block(structure[i])
+            if neighbor is None:
+                i += direction
+                continue
+            if neighbor.block_type in (BlockTypes.Text, BlockTypes.ListItem):
+                neighbor_json = self.normalize_block_json(neighbor, document, page)
+                neighbor_text = self._html_to_compact_text(
+                    neighbor_json.get("html", "")
+                )
+                if neighbor_text:
+                    collected.append(neighbor_text)
+            i += direction
+
+        joined = " ".join(collected).strip()
+        if len(joined) > self.neighbor_text_max_chars:
+            return joined[: self.neighbor_text_max_chars - 1].rstrip() + "…"
+        return joined
+
+    def _build_section_header_item(
+        self,
+        document: Document,
+        page: PageGroup,
+        block: Block,
+        raw_item: dict,
+        *,
+        page_index: dict[str, int],
+    ) -> dict:
+        item = dict(raw_item)
+        _, _, page_id, block_type, block_id = item["id"].split("/")
+        item["page"] = page_id
+        item["bbox"] = [self._round_1dp(v) for v in item["bbox"]]
+        item["width"] = self._round_1dp(item["bbox"][2] - item["bbox"][0])
+        item["height"] = self._round_1dp(item["bbox"][3] - item["bbox"][1])
+        item["left"] = item["bbox"][0]
+
+        line_height = block.line_height(document)
+        item["line_height"] = self._round_1dp(line_height)
+        page_height = page.polygon.height if page else 0
+        item["line_height_norm"] = self._round_1dp(
+            (line_height / page_height) * 1000 if page_height else 0
+        )
+
+        item["prev_text"] = self._get_neighbor_text(
+            document, page, block, direction=-1, page_index=page_index
+        )
+        item["next_text"] = self._get_neighbor_text(
+            document, page, block, direction=1, page_index=page_index
+        )
+
+        item.pop("block_type", None)  # Not needed, since they're all section headers
+        return item
+
+    def _build_recent_headers_context(
+        self,
+        document: Document,
+        section_header_blocks: list[Block],
+        *,
+        max_count: int,
+    ) -> list[dict]:
+        if max_count <= 0:
+            return []
+        recent: list[dict] = []
+        for block in section_header_blocks[-max_count:]:
+            page = document.get_page(block.page_id)
+            if page is None:
+                continue
+            block_json = self.normalize_block_json(block, document, page)
+            html = block_json.get("html", "")
+            recent.append(
+                {
+                    "id": str(block.id),
+                    "html": html,
+                    "level": self._extract_h_level(html),
+                }
+            )
+        return recent
 
     def get_selected_blocks(
         self,
@@ -130,51 +343,145 @@ Section Headers
     ):
         if self.llm_service is None:
             raise ValueError("LLM service is not configured")
-        section_header_json = [sh[1] for sh in section_headers]
-        for item in section_header_json:
-            _, _, page_id, block_type, block_id = item["id"].split("/")
-            item["page"] = page_id
-            item["width"] = item["bbox"][2] - item["bbox"][0]
-            item["height"] = item["bbox"][3] - item["bbox"][1]
-            del item["block_type"]  # Not needed, since they're all section headers
+        prompt_template = inject_analysis_prompt(self.page_prompt, self.analysis_style)
+        max_attempts = max(0, int(self.max_rewrite_retries)) + 1
+        max_chunk_tokens = int(self.max_chunk_tokens or 0)
 
-        prompt_template = inject_analysis_prompt(
-            self.page_prompt, self.analysis_style
-        )
-        prompt = prompt_template.replace(
-            "{{section_header_json}}", json.dumps(section_header_json)
-        )
-        headers = build_marker_trace_headers(
-            source_path=document.filepath,
-            processor=self.__class__.__name__,
-            block_id=str(document.pages[0].id),
-            page_id=document.pages[0].page_id,
-            extra={"SectionHeaderCount": len(section_header_json)},
-        )
-        response = self.llm_service(
-            prompt, None, document.pages[0], SectionHeaderSchema, extra_headers=headers
-        )
-        logger.debug(f"Got section header reponse from LLM: {response}")
+        page_indexes: dict[int, dict[str, int]] = {}
+        for page in document.pages:
+            if page.page_id is None:
+                continue
+            page_indexes[page.page_id] = self._page_structure_index(page)
 
-        normalized = self._normalize_response(response)
-        if normalized is None:
-            logger.warning("LLM did not return a valid response")
-            return
+        processed_blocks: list[Block] = []
+        cursor = 0
+        chunk_idx = 0
 
-        if not normalized.correction_needed:
-            return
+        while cursor < len(section_headers):
+            chunk_idx += 1
+            recent_ctx = self._build_recent_headers_context(
+                document, processed_blocks, max_count=int(self.recent_headers_max_count)
+            )
 
-        if not normalized.blocks:
-            return
+            chunk_blocks: list[Block] = []
+            chunk_items: list[dict] = []
 
-        self.handle_rewrites(normalized.blocks, document)
+            while cursor < len(section_headers):
+                block, raw_item = section_headers[cursor]
+                if block.page_id is None:
+                    cursor += 1
+                    continue
+                page = document.get_page(block.page_id)
+                if page is None:
+                    cursor += 1
+                    continue
+                if page.page_id is None:
+                    page_index = self._page_structure_index(page)
+                else:
+                    page_index = page_indexes.get(page.page_id) or self._page_structure_index(page)
+                    page_indexes[page.page_id] = page_index
+
+                candidate = self._build_section_header_item(
+                    document, page, block, raw_item, page_index=page_index
+                )
+                candidate_items = [*chunk_items, candidate]
+                prompt = (
+                    prompt_template.replace(
+                        "{{recent_headers_json}}", json.dumps(recent_ctx)
+                    )
+                    .replace("{{section_header_json}}", json.dumps(candidate_items))
+                )
+                tokens = self._count_prompt_tokens(prompt)
+                if max_chunk_tokens > 0 and tokens > max_chunk_tokens:
+                    if not chunk_items:
+                        chunk_items.append(candidate)
+                        chunk_blocks.append(block)
+                        cursor += 1
+                    break
+
+                chunk_items.append(candidate)
+                chunk_blocks.append(block)
+                cursor += 1
+
+            if not chunk_blocks:
+                continue
+
+            for attempt in range(1, max_attempts + 1):
+                refreshed_items: list[dict] = []
+                for block in chunk_blocks:
+                    if block.page_id is None:
+                        continue
+                    page = document.get_page(block.page_id)
+                    if page is None:
+                        continue
+                    if page.page_id is None:
+                        page_index = self._page_structure_index(page)
+                    else:
+                        page_index = page_indexes.get(page.page_id) or self._page_structure_index(page)
+                        page_indexes[page.page_id] = page_index
+                    raw_item = self.normalize_block_json(block, document, page)
+                    refreshed_items.append(
+                        self._build_section_header_item(
+                            document, page, block, raw_item, page_index=page_index
+                        )
+                    )
+
+                prompt = (
+                    prompt_template.replace(
+                        "{{recent_headers_json}}", json.dumps(recent_ctx)
+                    )
+                    .replace("{{section_header_json}}", json.dumps(refreshed_items))
+                )
+
+                headers = build_marker_trace_headers(
+                    source_path=document.filepath,
+                    processor=self.__class__.__name__,
+                    block_id=str(document.pages[0].id),
+                    page_id=document.pages[0].page_id,
+                    extra={
+                        "SectionHeaderCount": len(refreshed_items),
+                        "SectionHeaderChunkIndex": chunk_idx,
+                        "SectionHeaderAttempt": attempt,
+                    },
+                )
+                response = self.llm_service(
+                    prompt,
+                    None,
+                    document.pages[0],
+                    SectionHeaderSchema,
+                    extra_headers=headers,
+                )
+                logger.debug(
+                    f"section header prompt sent to LLM: {prompt}\n"
+                    f"Got section header reponse from LLM: {response}"
+                )
+
+                normalized = self._normalize_response(response)
+                if normalized is None:
+                    logger.warning("LLM did not return a valid response")
+                    return
+
+                if normalized.correction_needed and normalized.blocks:
+                    self.handle_rewrites(normalized.blocks, document)
+
+                if normalized.score >= 5 or attempt >= max_attempts:
+                    break
+
+                logger.info(
+                    "Section header rewriting low score %s on attempt %s/%s; retrying chunk %s.",
+                    normalized.score,
+                    attempt,
+                    max_attempts,
+                    chunk_idx,
+                )
+
+            processed_blocks.extend(chunk_blocks)
 
     def _normalize_response(self, response) -> _NormalizedSectionHeaderResponse | None:
         if response is None:
             return None
 
         if isinstance(response, str):
-            # TODO: is stripping code fences necessary?
             text = strip_code_fences(response)
             if string_indicates_no_corrections(text):
                 return _NormalizedSectionHeaderResponse(

--- a/marker/processors/llm/llm_sectionheader.py
+++ b/marker/processors/llm/llm_sectionheader.py
@@ -103,8 +103,8 @@ Section Headers
     ) -> List[dict]:
         selected_blocks = page.structure_blocks(document)
         json_blocks = [
-            self.normalize_block_json(block, document, page, i)
-            for i, block in enumerate(selected_blocks)
+            self.normalize_block_json(block, document, page)
+            for block in selected_blocks
         ]
         return json_blocks
 

--- a/marker/processors/llm/llm_table.py
+++ b/marker/processors/llm/llm_table.py
@@ -1,4 +1,3 @@
-import re
 from typing import Annotated, Any, List, cast
 
 from bs4 import BeautifulSoup
@@ -7,6 +6,11 @@ from marker.logger import get_logger
 from pydantic import BaseModel
 
 from marker.processors.llm import BaseLLMComplexBlockProcessor
+from marker.processors.llm.llm_utils import (
+    inject_analysis_prompt,
+    strip_code_fences,
+    string_indicates_no_corrections,
+)
 from marker.schema import BlockTypes
 from marker.schema.blocks import Block, TableCell, Table
 from marker.schema.document import Document
@@ -15,35 +19,6 @@ from marker.schema.polygon import PolygonBox
 from marker.telemetry import build_marker_trace_headers
 
 logger = get_logger()
-
-
-# TODO: centralise these helpers as they are used across a number of LLMProcessors.
-_NO_CORRECTION_PHRASES = (
-    "no_corrections",
-    "no corrections",
-    "no corrections needed",
-    "no correction needed",
-    "no correction required",
-    "no corrections required",
-    "no errors detected",
-    "no errors found",
-    "no changes needed",
-    "no change needed",
-    "looks good",
-)
-
-
-def _strip_code_fences(text: str) -> str:
-    text = text.strip()
-    if text.startswith("```"):
-        text = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", text)
-        text = re.sub(r"\n?```$", "", text)
-    return text.strip()
-
-
-def _string_indicates_no_corrections(text: str) -> bool:
-    lowered = text.lower()
-    return any(phrase in lowered for phrase in _NO_CORRECTION_PHRASES)
 
 
 def _int_attr(value: Any, default: int) -> int:
@@ -308,7 +283,7 @@ Output:
         corrected_html = response.get("corrected_html", "") or ""
 
         if correction_needed is None:
-            correction_needed = bool(corrected_html) and not _string_indicates_no_corrections(
+            correction_needed = bool(corrected_html) and not string_indicates_no_corrections(
                 corrected_html
             )
 
@@ -316,7 +291,7 @@ Output:
             return
 
         # Legacy fallback if LLM did not conform to JSON Schema instructions
-        if _string_indicates_no_corrections(corrected_html):
+        if string_indicates_no_corrections(corrected_html):
             return
 
         if not corrected_html:
@@ -324,10 +299,10 @@ Output:
             return
 
         # The original table is okay
-        if _string_indicates_no_corrections(corrected_html):
+        if string_indicates_no_corrections(corrected_html):
             return
 
-        corrected_html = _strip_code_fences(corrected_html)
+        corrected_html = strip_code_fences(corrected_html)
 
         # Re-iterate if low score
         total_iterations += 1

--- a/marker/processors/llm/llm_table.py
+++ b/marker/processors/llm/llm_table.py
@@ -1,4 +1,5 @@
-from typing import Annotated, List, Tuple
+import re
+from typing import Annotated, Any, List, cast
 
 from bs4 import BeautifulSoup
 from PIL import Image
@@ -60,7 +61,7 @@ def _int_attr(value: Any, default: int) -> int:
 
 class LLMTableProcessor(BaseLLMComplexBlockProcessor):
     block_types: Annotated[
-        Tuple[BlockTypes],
+        tuple[BlockTypes, ...],
         "The block types to process.",
     ] = (BlockTypes.Table, BlockTypes.TableOfContents)
     max_rows_per_batch: Annotated[
@@ -71,10 +72,11 @@ class LLMTableProcessor(BaseLLMComplexBlockProcessor):
         int,
         "The maximum number of rows in a table to process with the LLM processor.  Beyond this will be skipped.",
     ] = 175
-    table_image_expansion_ratio: Annotated[
+    # NOTE: renamed from `table_image_expansion_ratio`.
+    image_expansion_ratio: Annotated[
         float,
         "The ratio to expand the image by when cropping.",
-    ] = 0
+    ] = 0.01
     rotation_max_wh_ratio: Annotated[
         float,
         "The maximum width/height ratio for table cells for a table to be considered rotated.",

--- a/marker/processors/llm/llm_table.py
+++ b/marker/processors/llm/llm_table.py
@@ -62,7 +62,7 @@ class LLMTableProcessor(BaseLLMComplexBlockProcessor):
     ] = 2
     analysis_style: Annotated[
         str,
-        "How to structure the LLM analysis field: 'summary' or 'auto'.",
+        "How to structure the LLM analysis field: 'summary', 'deep', or 'auto'.",
     ] = "summary"
     table_rewriting_prompt: Annotated[
         str,

--- a/marker/processors/llm/llm_table.py
+++ b/marker/processors/llm/llm_table.py
@@ -60,6 +60,10 @@ class LLMTableProcessor(BaseLLMComplexBlockProcessor):
         int,
         "The maximum number of iterations to attempt rewriting a table.",
     ] = 2
+    analysis_style: Annotated[
+        str,
+        "How to structure the LLM analysis field: 'summary' or 'auto'.",
+    ] = "summary"
     table_rewriting_prompt: Annotated[
         str,
         "The prompt to use for rewriting text.",
@@ -81,16 +85,17 @@ Some guidelines:
 1. Carefully examine the provided text block image.
 2. Analyze the html representation of the table.
 3. Write a comparison of the image and the html representation, paying special attention to the column headers matching the correct column values.
-4. Output a single JSON object (and only JSON) matching this schema:
+4. {{analysis_instruction}}
+5. Output a single JSON object (and only JSON) matching this schema:
     - `comparison`: short string
-    - `analysis`: string. use as many words as you need and take as much time as you need to fully think, reason and analyse the image and the given html representation.
+    {{analysis_schema}}
     - `correction_needed`: boolean
     - `corrected_html`: corrected full table HTML (empty string when `correction_needed` is false)
     - `score`: integer 1-5 (use 5 when `correction_needed` is false), indicating your confidence in your analysis, and the quality of the corrected HTML representation.
-5. If the html representation is completely correct, set `correction_needed` to false and `corrected_html` to "".
-6. If you cannot read the image properly or fully, do your best to make as many corrections as you can, set `score` to 1 and `correction_needed` to True.
+6. If the html representation is completely correct, set `correction_needed` to false and `corrected_html` to "".
+7. If you cannot read the image properly or fully, do your best to make as many corrections as you can, set `score` to 1 and `correction_needed` to True.
     We will send your corrected HTML + image again for another round of correction.
-7. If the html representation has errors, set `correction_needed` to true and provide the corrected full table HTML in `corrected_html`.
+8. If the html representation has errors, set `correction_needed` to true and provide the corrected full table HTML in `corrected_html`.
 **Example:**
 Input:
 ```html
@@ -259,7 +264,10 @@ Output:
         if self.llm_service is None:
             raise ValueError("LLM service is not initialized")
 
-        prompt = self.table_rewriting_prompt.replace("{block_html}", block_html)
+        prompt_template = inject_analysis_prompt(
+            self.table_rewriting_prompt, self.analysis_style
+        )
+        prompt = prompt_template.replace("{block_html}", block_html)
 
         headers = build_marker_trace_headers(
             source_path=document.filepath,

--- a/marker/processors/llm/llm_table_merge.py
+++ b/marker/processors/llm/llm_table_merge.py
@@ -11,8 +11,10 @@ from marker.schema import BlockTypes
 from marker.schema.blocks import Block, TableCell
 from marker.schema.document import Document
 from marker.logger import get_logger
+from marker.telemetry import build_marker_trace_headers
 
 logger = get_logger()
+
 
 class LLMTableMergeProcessor(BaseLLMComplexBlockProcessor):
     block_types: Annotated[
@@ -25,27 +27,22 @@ class LLMTableMergeProcessor(BaseLLMComplexBlockProcessor):
     ] = 0.6
     table_start_threshold: Annotated[
         float,
-        "The maximum percentage down the page the second table can start to be considered for merging."
+        "The maximum percentage down the page the second table can start to be considered for merging.",
     ] = 0.2
     vertical_table_height_threshold: Annotated[
-        float,
-        "The height tolerance for 2 adjacent tables to be merged into one."
+        float, "The height tolerance for 2 adjacent tables to be merged into one."
     ] = 0.25
     vertical_table_distance_threshold: Annotated[
-        int,
-        "The maximum distance between table edges for adjacency."
+        int, "The maximum distance between table edges for adjacency."
     ] = 20
     horizontal_table_width_threshold: Annotated[
-        float,
-        "The width tolerance for 2 adjacent tables to be merged into one."
+        float, "The width tolerance for 2 adjacent tables to be merged into one."
     ] = 0.25
     horizontal_table_distance_threshold: Annotated[
-        int,
-        "The maximum distance between table edges for adjacency."
+        int, "The maximum distance between table edges for adjacency."
     ] = 10
     column_gap_threshold: Annotated[
-        int,
-        "The maximum gap between columns to merge tables"
+        int, "The maximum gap between columns to merge tables"
     ] = 50
     disable_tqdm: Annotated[
         bool,
@@ -58,7 +55,7 @@ class LLMTableMergeProcessor(BaseLLMComplexBlockProcessor):
     table_merge_prompt: Annotated[
         str,
         "The prompt to use for rewriting text.",
-        "Default is a string containing the Gemini rewriting prompt."
+        "Default is a string containing the Gemini rewriting prompt.",
     ] = """You're a text correction expert specializing in accurately reproducing tables from PDFs.
 You'll receive two images of tables from successive pages of a PDF.  Table 1 is from the first page, and Table 2 is from the second page.  Both tables may actually be part of the same larger table. Your job is to decide if Table 2 should be merged with Table 1, and how they should be joined.  The should only be merged if they're part of the same larger table, and Table 2 cannot be interpreted without merging.
 
@@ -156,7 +153,9 @@ Table 2
     def rewrite_blocks(self, document: Document):
         # Skip table merging if disabled via config
         if self.no_merge_tables_across_pages:
-            logger.info("Skipping table merging across pages due to --no_merge_tables_across_pages flag")
+            logger.info(
+                "Skipping table merging across pages due to --no_merge_tables_across_pages flag"
+            )
             return
 
         table_runs = []
@@ -168,43 +167,98 @@ Table 2
             for block in page_blocks:
                 merge_condition = False
                 if prev_block is not None:
-                    prev_cells = prev_block.contained_blocks(document, (BlockTypes.TableCell,))
-                    curr_cells = block.contained_blocks(document, (BlockTypes.TableCell,))
-                    row_match = abs(self.get_row_count(prev_cells) - self.get_row_count(curr_cells)) < 5, # Similar number of rows
-                    col_match = abs(self.get_column_count(prev_cells) - self.get_column_count(curr_cells)) < 2
+                    prev_cells = prev_block.contained_blocks(
+                        document, (BlockTypes.TableCell,)
+                    )
+                    curr_cells = block.contained_blocks(
+                        document, (BlockTypes.TableCell,)
+                    )
+                    row_match = (
+                        abs(
+                            self.get_row_count(prev_cells)
+                            - self.get_row_count(curr_cells)
+                        )
+                        < 5,
+                    )  # Similar number of rows
+                    col_match = (
+                        abs(
+                            self.get_column_count(prev_cells)
+                            - self.get_column_count(curr_cells)
+                        )
+                        < 2
+                    )
 
-                    subsequent_page_table = all([
-                        prev_block.page_id == block.page_id - 1, # Subsequent pages
-                        max(prev_block.polygon.height / page.polygon.height,
-                            block.polygon.height / page.polygon.height) > self.table_height_threshold, # Take up most of the page height
-                            (len(page_blocks) == 1 or prev_page_block_count == 1), # Only table on the page
-                            (row_match or col_match)
-                        ])
+                    subsequent_page_table = all(
+                        [
+                            prev_block.page_id == block.page_id - 1,  # Subsequent pages
+                            max(
+                                prev_block.polygon.height / page.polygon.height,
+                                block.polygon.height / page.polygon.height,
+                            )
+                            > self.table_height_threshold,  # Take up most of the page height
+                            (
+                                len(page_blocks) == 1 or prev_page_block_count == 1
+                            ),  # Only table on the page
+                            (row_match or col_match),
+                        ]
+                    )
 
-                    same_page_vertical_table = all([
-                        prev_block.page_id == block.page_id, # On the same page
-                        (1 - self.vertical_table_height_threshold) < prev_block.polygon.height / block.polygon.height < (1 + self.vertical_table_height_threshold), # Similar height
-                        abs(block.polygon.x_start - prev_block.polygon.x_end) < self.vertical_table_distance_threshold, # Close together in x
-                        abs(block.polygon.y_start - prev_block.polygon.y_start) < self.vertical_table_distance_threshold, # Close together in y
-                        row_match
-                    ])
+                    same_page_vertical_table = all(
+                        [
+                            prev_block.page_id == block.page_id,  # On the same page
+                            (1 - self.vertical_table_height_threshold)
+                            < prev_block.polygon.height / block.polygon.height
+                            < (
+                                1 + self.vertical_table_height_threshold
+                            ),  # Similar height
+                            abs(block.polygon.x_start - prev_block.polygon.x_end)
+                            < self.vertical_table_distance_threshold,  # Close together in x
+                            abs(block.polygon.y_start - prev_block.polygon.y_start)
+                            < self.vertical_table_distance_threshold,  # Close together in y
+                            row_match,
+                        ]
+                    )
 
-                    same_page_horizontal_table = all([
-                        prev_block.page_id == block.page_id, # On the same page
-                        (1 - self.horizontal_table_width_threshold) < prev_block.polygon.width / block.polygon.width < (1 + self.horizontal_table_width_threshold), # Similar width
-                        abs(block.polygon.y_start - prev_block.polygon.y_end) < self.horizontal_table_distance_threshold, # Close together in y
-                        abs(block.polygon.x_start - prev_block.polygon.x_start) < self.horizontal_table_distance_threshold, # Close together in x
-                        col_match
-                    ])
+                    same_page_horizontal_table = all(
+                        [
+                            prev_block.page_id == block.page_id,  # On the same page
+                            (1 - self.horizontal_table_width_threshold)
+                            < prev_block.polygon.width / block.polygon.width
+                            < (
+                                1 + self.horizontal_table_width_threshold
+                            ),  # Similar width
+                            abs(block.polygon.y_start - prev_block.polygon.y_end)
+                            < self.horizontal_table_distance_threshold,  # Close together in y
+                            abs(block.polygon.x_start - prev_block.polygon.x_start)
+                            < self.horizontal_table_distance_threshold,  # Close together in x
+                            col_match,
+                        ]
+                    )
 
-                    same_page_new_column = all([
-                        prev_block.page_id == block.page_id, # On the same page
-                        abs(block.polygon.x_start - prev_block.polygon.x_end) < self.column_gap_threshold,
-                        block.polygon.y_start < prev_block.polygon.y_end,
-                        block.polygon.width * (1 - self.vertical_table_height_threshold) < prev_block.polygon.width  < block.polygon.width * (1 + self.vertical_table_height_threshold), # Similar width
-                        col_match
-                    ])
-                    merge_condition = any([subsequent_page_table, same_page_vertical_table, same_page_new_column, same_page_horizontal_table])
+                    same_page_new_column = all(
+                        [
+                            prev_block.page_id == block.page_id,  # On the same page
+                            abs(block.polygon.x_start - prev_block.polygon.x_end)
+                            < self.column_gap_threshold,
+                            block.polygon.y_start < prev_block.polygon.y_end,
+                            block.polygon.width
+                            * (1 - self.vertical_table_height_threshold)
+                            < prev_block.polygon.width
+                            < block.polygon.width
+                            * (
+                                1 + self.vertical_table_height_threshold
+                            ),  # Similar width
+                            col_match,
+                        ]
+                    )
+                    merge_condition = any(
+                        [
+                            subsequent_page_table,
+                            same_page_vertical_table,
+                            same_page_new_column,
+                            same_page_horizontal_table,
+                        ]
+                    )
 
                 if prev_block is not None and merge_condition:
                     if prev_block not in table_run:
@@ -232,10 +286,12 @@ Table 2
         )
 
         with ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
-            for future in as_completed([
-                executor.submit(self.process_rewriting, document, blocks)
-                for blocks in table_runs
-            ]):
+            for future in as_completed(
+                [
+                    executor.submit(self.process_rewriting, document, blocks)
+                    for blocks in table_runs
+                ]
+            ):
                 future.result()  # Raise exceptions if any occurred
                 pbar.update(1)
 
@@ -250,7 +306,9 @@ Table 2
         for i in range(1, len(blocks)):
             curr_block = blocks[i]
             children = start_block.contained_blocks(document, (BlockTypes.TableCell,))
-            children_curr = curr_block.contained_blocks(document, (BlockTypes.TableCell,))
+            children_curr = curr_block.contained_blocks(
+                document, (BlockTypes.TableCell,)
+            )
             if not children or not children_curr:
                 # Happens if table/form processors didn't run
                 break
@@ -260,13 +318,26 @@ Table 2
             start_html = json_to_html(start_block.render(document))
             curr_html = json_to_html(curr_block.render(document))
 
-            prompt = self.table_merge_prompt.replace("{{table1}}", start_html).replace("{{table2}}", curr_html)
+            prompt = self.table_merge_prompt.replace("{{table1}}", start_html).replace(
+                "{{table2}}", curr_html
+            )
 
+            headers = build_marker_trace_headers(
+                source_path=document.filepath,
+                processor=self.__class__.__name__,
+                block_id=str(curr_block.id),
+                page_id=curr_block.page_id,
+                extra={
+                    "MergeStep": f"{i}/{len(blocks) - 1}",
+                    "MergeStart": str(start_block.id),
+                },
+            )
             response = self.llm_service(
                 prompt,
                 [start_image, curr_image],
                 curr_block,
                 MergeSchema,
+                extra_headers=headers,
             )
 
             if not response or ("direction" not in response or "merge" not in response):
@@ -292,7 +363,12 @@ Table 2
             start_block.structure = [b.id for b in merged_cells]
             start_block.lowres_image = merged_image
 
-    def validate_merge(self, cells1: List[TableCell], cells2: List[TableCell], direction: Literal['right', 'bottom'] = 'right'):
+    def validate_merge(
+        self,
+        cells1: List[TableCell],
+        cells2: List[TableCell],
+        direction: Literal["right", "bottom"] = "right",
+    ):
         if direction == "right":
             # Check if the number of rows is the same
             cells1_row_count = self.get_row_count(cells1)
@@ -304,9 +380,13 @@ Table 2
             cells2_col_count = self.get_column_count(cells2)
             return abs(cells1_col_count - cells2_col_count) < 2
 
-
-    def join_cells(self, cells1: List[TableCell], cells2: List[TableCell], direction: Literal['right', 'bottom'] = 'right') -> List[TableCell]:
-        if direction == 'right':
+    def join_cells(
+        self,
+        cells1: List[TableCell],
+        cells2: List[TableCell],
+        direction: Literal["right", "bottom"] = "right",
+    ) -> List[TableCell]:
+        if direction == "right":
             # Shift columns right
             col_count = self.get_column_count(cells1)
             for cell in cells2:
@@ -321,21 +401,25 @@ Table 2
         return new_cells
 
     @staticmethod
-    def join_images(image1: Image.Image, image2: Image.Image, direction: Literal['right', 'bottom'] = 'right') -> Image.Image:
+    def join_images(
+        image1: Image.Image,
+        image2: Image.Image,
+        direction: Literal["right", "bottom"] = "right",
+    ) -> Image.Image:
         # Get dimensions
         w1, h1 = image1.size
         w2, h2 = image2.size
 
-        if direction == 'right':
+        if direction == "right":
             new_height = max(h1, h2)
             new_width = w1 + w2
-            new_img = Image.new('RGB', (new_width, new_height), 'white')
+            new_img = Image.new("RGB", (new_width, new_height), "white")
             new_img.paste(image1, (0, 0))
             new_img.paste(image2, (w1, 0))
         else:
             new_width = max(w1, w2)
             new_height = h1 + h2
-            new_img = Image.new('RGB', (new_width, new_height), 'white')
+            new_img = Image.new("RGB", (new_width, new_height), "white")
             new_img.paste(image1, (0, 0))
             new_img.paste(image2, (0, h1))
         return new_img

--- a/marker/processors/llm/llm_utils.py
+++ b/marker/processors/llm/llm_utils.py
@@ -1,0 +1,28 @@
+import re
+
+NO_CORRECTION_PHRASES = (
+    "no_corrections",
+    "no corrections",
+    "no corrections needed",
+    "no correction needed",
+    "no correction required",
+    "no corrections required",
+    "no errors detected",
+    "no errors found",
+    "no changes needed",
+    "no change needed",
+    "looks good",
+)
+
+
+def strip_code_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text)
+    return text.strip()
+
+
+def string_indicates_no_corrections(text: str) -> bool:
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in NO_CORRECTION_PHRASES)

--- a/marker/processors/llm/llm_utils.py
+++ b/marker/processors/llm/llm_utils.py
@@ -35,8 +35,8 @@ def get_analysis_prompt_parts(style: str | None) -> tuple[str, str]:
     Parameters
     ----------
     style : str | None
-        The style of analysis prompt to generate. 
-        Can be "summary", "auto" or None for default.
+        The style of analysis prompt to generate.
+        Can be "summary", "deep", "auto" or None for default.
         Defaults to "auto" if None.
 
     Returns
@@ -49,6 +49,11 @@ def get_analysis_prompt_parts(style: str | None) -> tuple[str, str]:
         return (
             "Write a short analysis.",
             "- `analysis`: short string",
+        )
+    if normalized == "deep":
+        return (
+            "Write a deep and detailed analysis. Include step-by-step reasoning and thorough explanations.",
+            "- `analysis`: detailed string with step-by-step reasoning",
         )
     return (
         "Write an analysis. Keep it concise unless a longer reasoning process is necessary. "

--- a/marker/processors/llm/llm_utils.py
+++ b/marker/processors/llm/llm_utils.py
@@ -26,3 +26,40 @@ def strip_code_fences(text: str) -> str:
 def string_indicates_no_corrections(text: str) -> bool:
     lowered = text.lower()
     return any(phrase in lowered for phrase in NO_CORRECTION_PHRASES)
+
+
+def get_analysis_prompt_parts(style: str | None) -> tuple[str, str]:
+    """
+    Get the instruction and schema parts for the analysis prompt based on the style.
+
+    Parameters
+    ----------
+    style : str | None
+        The style of analysis prompt to generate. 
+        Can be "summary", "auto" or None for default.
+        Defaults to "auto" if None.
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple containing the instruction and schema parts for the analysis prompt.
+    """
+    normalized = (style or "auto").strip().lower()
+    if normalized == "summary":
+        return (
+            "Write a short analysis.",
+            "- `analysis`: short string",
+        )
+    return (
+        "Write an analysis. Keep it concise unless a longer reasoning process is necessary.",
+        "- `analysis`: string. Keep it short unless a longer reasoning process is necessary.",
+    )
+
+
+def inject_analysis_prompt(prompt: str, style: str | None) -> str:
+    instruction, schema = get_analysis_prompt_parts(style)
+    return (
+        prompt.replace("{{analysis_instruction}}", instruction).replace(
+            "{{analysis_schema}}", schema
+        )
+    )

--- a/marker/processors/llm/llm_utils.py
+++ b/marker/processors/llm/llm_utils.py
@@ -51,8 +51,10 @@ def get_analysis_prompt_parts(style: str | None) -> tuple[str, str]:
             "- `analysis`: short string",
         )
     return (
-        "Write an analysis. Keep it concise unless a longer reasoning process is necessary.",
-        "- `analysis`: string. Keep it short unless a longer reasoning process is necessary.",
+        "Write an analysis. Keep it concise unless a longer reasoning process is necessary. "
+        "If the task is difficult, you must enter a detailed reasoning process and think step by step.",
+        "- `analysis`: string. Keep it concise unless a longer reasoning process is necessary. "
+        "If the task is difficult, you must enter a detailed reasoning process and think step by step.",
     )
 
 

--- a/marker/processors/order.py
+++ b/marker/processors/order.py
@@ -1,4 +1,3 @@
-from statistics import mean
 from collections import defaultdict
 
 from marker.processors import BaseProcessor
@@ -10,6 +9,7 @@ class OrderProcessor(BaseProcessor):
     """
     A processor for sorting the blocks in order if needed.  This can help when the layout image was sliced.
     """
+
     block_types = tuple()
 
     def __call__(self, document: Document):
@@ -25,12 +25,14 @@ class OrderProcessor(BaseProcessor):
             block_idxs = defaultdict(int)
             for block_id in page.structure:
                 block = document.get_block(block_id)
-                spans = block.contained_blocks(document, (BlockTypes.Span, ))
+                spans = block.contained_blocks(document, (BlockTypes.Span,))
                 if len(spans) == 0:
                     continue
 
                 # Avg span position in original PDF
-                block_idxs[block_id] = (spans[0].minimum_position + spans[-1].maximum_position) / 2
+                block_idxs[block_id] = (
+                    spans[0].minimum_position + spans[-1].maximum_position
+                ) / 2
 
             for block_id in page.structure:
                 # Already assigned block id via span position
@@ -63,4 +65,3 @@ class OrderProcessor(BaseProcessor):
                     block_idxs[block_id] = block_idxs[next_block.id] + block_idx_add
 
             page.structure = sorted(page.structure, key=lambda x: block_idxs[x])
-

--- a/marker/providers/html.py
+++ b/marker/providers/html.py
@@ -6,6 +6,7 @@ from marker.providers.pdf import PdfProvider
 
 class HTMLProvider(PdfProvider):
     def __init__(self, filepath: str, config=None):
+        self.source_filepath = filepath
         temp_pdf = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
         self.temp_pdf_path = temp_pdf.name
         temp_pdf.close()

--- a/marker/schema/blocks/base.py
+++ b/marker/schema/blocks/base.py
@@ -101,6 +101,7 @@ class Block(BaseModel):
     highres_image: Image.Image | None = None
     removed: bool = False  # Has block been replaced by new block?
     _metadata: Optional[dict] = None
+    html: str | None = None  # will be populated by processors such as LLMFormProcessor
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/marker/services/__init__.py
+++ b/marker/services/__init__.py
@@ -1,7 +1,7 @@
-from typing import Optional, List, Annotated
+from typing import Optional, List, Annotated, Mapping
 from io import BytesIO
 
-import PIL
+from PIL import Image
 from pydantic import BaseModel
 
 from marker.schema.blocks import Block
@@ -19,12 +19,12 @@ class BaseService:
         int, "The maximum number of output tokens to generate."
     ] = None
 
-    def img_to_base64(self, img: PIL.Image.Image, format: str = "WEBP"):
+    def img_to_base64(self, img: Image.Image, format: str = "WEBP"):
         image_bytes = BytesIO()
         img.save(image_bytes, format=format)
         return base64.b64encode(image_bytes.getvalue()).decode("utf-8")
 
-    def process_images(self, images: List[PIL.Image.Image]) -> list:
+    def process_images(self, images: List[Image.Image]) -> list:
         raise NotImplementedError
 
     def format_image_for_llm(self, image):
@@ -46,10 +46,11 @@ class BaseService:
     def __call__(
         self,
         prompt: str,
-        image: PIL.Image.Image | List[PIL.Image.Image] | None,
+        image: Image.Image | List[Image.Image] | None,
         block: Block | None,
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        extra_headers: Mapping[str, str] | None = None,
     ):
         raise NotImplementedError

--- a/marker/services/claude.py
+++ b/marker/services/claude.py
@@ -1,8 +1,7 @@
 import json
 import time
-from typing import List, Annotated, T
+from typing import List, Annotated, Mapping, T
 
-import PIL
 from PIL import Image
 import anthropic
 from anthropic import RateLimitError, APITimeoutError
@@ -66,11 +65,12 @@ class ClaudeService(BaseService):
     def __call__(
         self,
         prompt: str,
-        image: PIL.Image.Image | List[PIL.Image.Image] | None,
+        image: Image.Image | List[Image.Image] | None,
         block: Block | None,
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        extra_headers: Mapping[str, str] | None = None,
     ):
         if max_retries is None:
             max_retries = self.max_retries

--- a/marker/services/gemini.py
+++ b/marker/services/gemini.py
@@ -2,9 +2,9 @@ import json
 import time
 import traceback
 from io import BytesIO
-from typing import List, Annotated
+from typing import List, Annotated, Mapping
 
-import PIL
+from PIL import Image
 from google import genai
 from google.genai import types
 from google.genai.errors import APIError
@@ -25,7 +25,7 @@ class BaseGeminiService(BaseService):
         int, "The thinking token budget to use for the service."
     ] = None
 
-    def img_to_bytes(self, img: PIL.Image.Image):
+    def img_to_bytes(self, img: Image.Image):
         image_bytes = BytesIO()
         img.save(image_bytes, format="WEBP")
         return image_bytes.getvalue()
@@ -43,11 +43,12 @@ class BaseGeminiService(BaseService):
     def __call__(
         self,
         prompt: str,
-        image: PIL.Image.Image | List[PIL.Image.Image] | None,
+        image: Image.Image | List[Image.Image] | None,
         block: Block | None,
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        extra_headers: Mapping[str, str] | None = None,
     ):
         if max_retries is None:
             max_retries = self.max_retries

--- a/marker/services/ollama.py
+++ b/marker/services/ollama.py
@@ -1,7 +1,7 @@
 import json
-from typing import Annotated, List
+from typing import Annotated, List, Mapping
 
-import PIL
+from PIL import Image
 import requests
 from marker.logger import get_logger
 from pydantic import BaseModel
@@ -27,11 +27,12 @@ class OllamaService(BaseService):
     def __call__(
         self,
         prompt: str,
-        image: PIL.Image.Image | List[PIL.Image.Image] | None,
+        image: Image.Image | List[Image.Image] | None,
         block: Block | None,
         response_schema: type[BaseModel],
         max_retries: int | None = None,
         timeout: int | None = None,
+        extra_headers: Mapping[str, str] | None = None,
     ):
         url = f"{self.ollama_base_url}/api/generate"
         headers = {"Content-Type": "application/json"}

--- a/marker/services/vertex.py
+++ b/marker/services/vertex.py
@@ -4,6 +4,7 @@ from google import genai
 
 from marker.services.gemini import BaseGeminiService
 
+
 class GoogleVertexService(BaseGeminiService):
     vertex_project_id: Annotated[
         str,
@@ -14,16 +15,14 @@ class GoogleVertexService(BaseGeminiService):
         "Google Cloud Location for Vertex AI.",
     ] = "us-central1"
     gemini_model_name: Annotated[
-        str,
-        "The name of the Google model to use for the service."
+        str, "The name of the Google model to use for the service."
     ] = "gemini-2.0-flash-001"
     vertex_dedicated: Annotated[
-        bool,
-        "Whether to use a dedicated Vertex AI instance."
+        bool, "Whether to use a dedicated Vertex AI instance."
     ] = False
 
     def get_google_client(self, timeout: int):
-        http_options = {"timeout": timeout * 1000} # Convert to milliseconds
+        http_options = {"timeout": timeout * 1000}  # Convert to milliseconds
         if self.vertex_dedicated:
             http_options["headers"] = {"x-vertex-ai-llm-request-type": "dedicated"}
         return genai.Client(

--- a/marker/telemetry.py
+++ b/marker/telemetry.py
@@ -1,0 +1,56 @@
+import os
+from typing import Any, Mapping
+
+
+def _sanitize_header_value(value: Any, *, max_len: int = 512) -> str:
+    text = str(value)
+    text = text.replace("\r", " ").replace("\n", " ").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def sanitize_headers(headers: Mapping[str, Any] | None) -> dict[str, str]:
+    if not headers:
+        return {}
+    cleaned: dict[str, str] = {}
+    for key, value in headers.items():
+        if value is None:
+            continue
+        cleaned[str(key)] = _sanitize_header_value(value)
+    return cleaned
+
+
+def build_marker_trace_headers(
+    *,
+    source_path: str | None = None,
+    processor: str | None = None,
+    block_id: str | None = None,
+    page_id: int | str | None = None,
+    extra: Mapping[str, Any] | None = None,
+    max_source_len: int = 256,
+) -> dict[str, str]:
+    headers: dict[str, Any] = {}
+
+    if source_path:
+        source_path = str(source_path)
+        headers["X-Marker-Source-File"] = os.path.basename(source_path)
+        headers["X-Marker-Source"] = _sanitize_header_value(source_path, max_len=max_source_len)
+
+    if processor:
+        headers["X-Marker-Processor"] = processor
+
+    if block_id:
+        headers["X-Marker-Block"] = block_id
+
+    if page_id is not None:
+        headers["X-Marker-Page"] = page_id
+
+    if extra:
+        for k, v in extra.items():
+            if v is None:
+                continue
+            headers[f"X-Marker-{k}"] = v
+
+    return sanitize_headers(headers)
+


### PR DESCRIPTION
I made these fixes and improvements to make `marker` even more powerful for my side project. So far I have tested on 100+ SEC filings (10Q and 10K) of various publicly listed companies. These are extremely long documents with anywhere from 30k to 100k+ tokens with multiple tables. So far, I am very, very pleased with the results. 

All changes are described in detail below.

A key finding I made was that explicitly asking the LLM to think deeper during the LLM processing steps immensely improves the results. In particular, this virtually removed all errors from the LLMTableProcessing step, especially when the initial OCR pipeline made severe mistakes. I used a locally hosted (via vLLM) Qwen/Qwen3-VL-32B-Instruct-FP8 model for this. I initially used allenai/olmOCR-2-7B-1025-FP8 , but it was struggling a lot on all tasks, usually making no corrections and claiming that everything was correct. Along with these, I also improved the various schemas and output parsing. Finally, I fixed a number of bugs. 

For my experiments, I ran this script https://github.com/linminhtoo/finance-rag-assistant-v2/blob/mlin/v1.1/scripts/process_html_to_markdown.sh after downloading HTMLs using download.sh. 

All in all, I've tried to keep changes backward compatible, preserving the existing `marker` behavior as much as possible, with the new "bells and whistles" requiring users to explicitly enable them to take effect.

Please let me know if and how I should re-run any of the benchmarks or tests to prove that these changes are not detrimental. I noticed that there is no automatic pytest CI/CD hook, maybe we want to implement that soon. 

---

## CHANGELOG

### Added
- Tracing/telemetry helpers via `marker/telemetry.py`:
  - `build_marker_trace_headers()` to generate `X-Marker-*` headers (source file/path, processor, page, block, and extra context). These are extremely useful for tracing LLM calls to debug intermediate steps as well as monitor per-step latency. 
  - `sanitize_headers()` to safely strip/clip header values
- Shared LLM utilities in `marker/processors/llm/llm_utils.py`:
  - `inject_analysis_prompt()` with `analysis_style` support (`summary` / `deep` / `auto`)
  - `strip_code_fences()` and `string_indicates_no_corrections()` helpers for more robust response parsing
- `analysis_style` options for LLM processors (opt-in “deeper thinking” prompts), used in:
  - `LLMTableProcessor` (`marker/processors/llm/llm_table.py`)
  - `LLMPageCorrectionProcessor` (`marker/processors/llm/llm_page_correction.py`)
  - `LLMSectionHeaderProcessor` (`marker/processors/llm/llm_sectionheader.py`)
  - By allowing the LLM to "reason" by outputting text tokens into the `"analysis"` output field of the schema, we can drastically improve accuracy of results.  
- `LLMSectionHeaderProcessor` chunking + additional context knobs (all default to “off” to preserve existing behavior):
  - `max_chunk_tokens`, `chunk_tokenizer_hf_model_id` (best-effort HF tokenizer based token counting)
  - `neighbor_text_max_blocks`, `neighbor_text_max_chars` (inject nearby text around each header)
  - `recent_headers_max_count` (carry forward recently-fixed headers as anchoring context)
  - `max_rewrite_retries` + a `score` field to optionally retry low-confidence chunks

### Changed
- LLM prompts/schemas updated to prefer structured JSON outputs (with legacy fallbacks still handled in many places):
  - `LLMTableProcessor`, `LLMMathBlockProcessor`, `LLMFormProcessor`, `LLMPageCorrectionProcessor`, `LLMSectionHeaderProcessor`
  - In particular, added explicit `correction_needed: bool` fields that can be quickly checked before further parsing.
- Service interface extended to support tracing headers:
  - `BaseService.__call__(..., extra_headers: Mapping[str, str] | None = None)` in `marker/services/__init__.py`
  - All concrete services now accept `extra_headers`: `OpenAIService`, `AzureOpenAIService`, `ClaudeService`, `BaseGeminiService` (and `GoogleVertexService`), `OllamaService`
  - `OpenAIService` and `AzureOpenAIService` pass/sanitize `extra_headers` and attach default request headers (`X-Title`, `HTTP-Referer`) plus `X-Marker-Block` when available
- `LLMTableProcessor`:
  - Adds table chunk context to trace headers (`TableChunk`, `RowStart/RowEnd`, `Iteration`)
  - Renames `table_image_expansion_ratio` → `image_expansion_ratio` (note: config key rename)
- `HTMLProvider` stores `source_filepath` for easier debugging/tracing (`marker/providers/html.py`)

### Fixed
- `LLMPageCorrectionProcessor` response handling is more robust (normalizes string/list/dict responses, handles code fences and “no corrections” phrases, infers correction type when missing). 
    - Also fixed a bug where corrections could be wrongly skipped/mishandled just because the user did not specify their own prompt. The logic now correctly falls back to the default prompt.
- `PageGroup.get_image()` now consistently returns a PIL `Image.Image` even when the stored image is bytes/memoryview (`marker/schema/groups/page.py`)
- `PromptData.schema` typing corrected to `type[BaseModel]` (`marker/processors/llm/__init__.py`)
- `Block` now includes an optional `html` field (used by processors like `LLMFormProcessor`) (`marker/schema/blocks/base.py`)
- Minor prompt/parse correctness improvements across `LLMTableProcessor`, `LLMMathBlockProcessor`, and `LLMFormProcessor` (better schema adherence, code-fence stripping, “no corrections” detection)

### Notes / Migration
- Custom service implementations must accept the new `extra_headers` kwarg (added to `BaseService.__call__`).
- If you previously configured `LLMTableProcessor.table_image_expansion_ratio` (this was most likely a typo bug that was not fixed), migrate to `LLMTableProcessor.image_expansion_ratio`.

---
## Other notes 

I implemented a custom OpenAIService wrapper at https://github.com/linminhtoo/finance-rag-assistant-v2/blob/mlin/v1.1/scripts/process_html_to_markdown.py#L46 
- There are some features we may want to bring in. For example, I have a knob to cap the max long side of images sent to the LLM. Without this, depending on the PDF, very large images could be sent to the LLM, resulting in thousands of image tokens which greatly slows down the requests. In my use-case, limiting the max long side it to ~1200 speeds up the requests without sacrificing accuracy.
- The concept of "max retries' was a little confusing at first. The `marker` retry loop actually overlaps with the internal `OpenAI` SDK's retry mechanism, causing excessive requests to the API. We may want to either set the API SDK's retries to 0 and use the marker retry mechanism, or vice versa. 

In my opinion, the most brittle step at the moment is the `LLMSectionHeaderProcessor.`
- I wanted to make sure this step gives good results as it would affect downstream document hierarchy parsing and hierarchical chunking, where chunks for RAG are constructed based on relative section levels. An accurate hierarchy would allow for more intricate retrieval patterns during RAG - for example, fetching section-neighbor chunks, parent chunks or child chunks, which have been shown to boost RAG accuracy. 
- For starter's, I found that my LLM calls at this step had upwards of 15k-40k tokens, which I felt was making it too difficult for the LLM. I experimented with breaking up into chunks of ~10k tokens (this limit includes all the additional text context, so the actual number of headers in each chunk is significantly reduced). I also injected additional context around each header, namely the line height information and nearby text from the document. Finally, I also included recently-corrected headers from previous chunks into the prompt. 
- All these improve the results a bit, but there are still occasional inconsistencies where heading levels jump around or are not consistent across multiple pages. My main suspicion is that the LLM does not have enough "anchoring" information to decide the truly appropriate header levels, especially when there are "inconsistencies" in the OCR/recognition results. 
- Even so, the current processor does work reasonably well and is a great baseline. 

Also, I started from https://github.com/datalab-to/marker/pull/962 and removed linting (ruff formatting) commits which were a result of running `pre-commit run --all`. I suggest we have a separate dedicated PR just to run this ruff formatting. 