### PR TITLE
Change default_processors to use Type[BaseProcessor]

### DIFF
--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -71,7 +71,7 @@ class PdfConverter(BaseConverter):
         bool,
         "Enable higher quality processing with LLMs.",
     ] = False
-    default_processors: Tuple[BaseProcessor, ...] = (
+    default_processors: Tuple[Type[BaseProcessor], ...] = (
         OrderProcessor,
         BlockRelabelProcessor,
         LineMergeProcessor,


### PR DESCRIPTION
Fix of the type hint for default_processors, given its elements are classes that inherit from BaseProcessor, rather than instances