### PR TITLE
fix: Add fallback for OpenAI-compatible APIs without Structured Outputs

### DIFF
--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -1,11 +1,11 @@
 import json
 import time
-from typing import Annotated, List
+from typing import Annotated, List, TypeVar
 
 import openai
 import PIL
 from marker.logger import get_logger
-from openai import APITimeoutError, RateLimitError
+from openai import APITimeoutError, RateLimitError, BadRequestError
 from PIL import Image
 from pydantic import BaseModel
 
@@ -13,6 +13,8 @@ from marker.schema.blocks import Block
 from marker.services import BaseService
 
 logger = get_logger()
+
+T = TypeVar("T")
 
 
 class OpenAIService(BaseService):
@@ -29,6 +31,10 @@ class OpenAIService(BaseService):
         str,
         "The image format to use for the OpenAI-like service. Use 'png' for better compatability",
     ] = "webp"
+    openai_disable_structured_output: Annotated[
+        bool,
+        "Disable Structured Outputs (response_format) for APIs that don't support it (e.g., DeepSeek).",
+    ] = False
 
     def process_images(self, images: List[Image.Image]) -> List[dict]:
         """
@@ -58,6 +64,90 @@ class OpenAIService(BaseService):
             for img in images
         ]
 
+    def validate_response(self, response_text: str, schema: type[T]) -> dict | None:
+        """
+        Parse JSON from plain text response.
+        Used as fallback for APIs that don't support Structured Outputs.
+        """
+        response_text = response_text.strip()
+        if response_text.startswith("```json"):
+            response_text = response_text[7:]
+        if response_text.startswith("```"):
+            response_text = response_text[3:]
+        if response_text.endswith("```"):
+            response_text = response_text[:-3]
+
+        try:
+            # Try to parse as JSON first
+            out_schema = schema.model_validate_json(response_text)
+            return out_schema.model_dump()
+        except Exception:
+            try:
+                # Re-parse with fixed escapes
+                escaped_str = response_text.replace("\\", "\\\\")
+                out_schema = schema.model_validate_json(escaped_str)
+                return out_schema.model_dump()
+            except Exception:
+                return None
+
+    def _call_with_structured_output(
+        self,
+        client: openai.OpenAI,
+        messages: list,
+        response_schema: type[BaseModel],
+        timeout: int,
+    ) -> dict | None:
+        """Call OpenAI API using Structured Outputs (response_format)."""
+        response = client.beta.chat.completions.parse(
+            extra_headers={
+                "X-Title": "Marker",
+                "HTTP-Referer": "https://github.com/datalab-to/marker",
+            },
+            model=self.openai_model,
+            messages=messages,
+            timeout=timeout,
+            response_format=response_schema,
+        )
+        response_text = response.choices[0].message.content
+        return json.loads(response_text), response.usage.total_tokens
+
+    def _call_with_fallback(
+        self,
+        client: openai.OpenAI,
+        messages: list,
+        response_schema: type[BaseModel],
+        timeout: int,
+    ) -> dict | None:
+        """
+        Call OpenAI API using plain chat completions with schema in prompt.
+        Fallback for APIs that don't support Structured Outputs.
+        """
+        schema_example = response_schema.model_json_schema()
+        system_prompt = f"""Follow the instructions given by the user prompt. You must provide your response in JSON format matching this schema:
+
+{json.dumps(schema_example, indent=2)}
+
+Respond only with the JSON, nothing else. Do not include ```json, ```, or any other formatting."""
+
+        # Prepend system message
+        messages_with_system = [
+            {"role": "system", "content": system_prompt},
+            *messages,
+        ]
+
+        response = client.chat.completions.create(
+            extra_headers={
+                "X-Title": "Marker",
+                "HTTP-Referer": "https://github.com/datalab-to/marker",
+            },
+            model=self.openai_model,
+            messages=messages_with_system,
+            timeout=timeout,
+        )
+        response_text = response.choices[0].message.content
+        parsed = self.validate_response(response_text, response_schema)
+        return parsed, response.usage.total_tokens
+
     def __call__(
         self,
         prompt: str,
@@ -86,26 +176,49 @@ class OpenAIService(BaseService):
             }
         ]
 
+        # Track if we should use fallback mode
+        use_fallback = self.openai_disable_structured_output
+
         total_tries = max_retries + 1
         for tries in range(1, total_tries + 1):
             try:
-                response = client.beta.chat.completions.parse(
-                    extra_headers={
-                        "X-Title": "Marker",
-                        "HTTP-Referer": "https://github.com/datalab-to/marker",
-                    },
-                    model=self.openai_model,
-                    messages=messages,
-                    timeout=timeout,
-                    response_format=response_schema,
-                )
-                response_text = response.choices[0].message.content
-                total_tokens = response.usage.total_tokens
+                if use_fallback:
+                    result, total_tokens = self._call_with_fallback(
+                        client, messages, response_schema, timeout
+                    )
+                else:
+                    result, total_tokens = self._call_with_structured_output(
+                        client, messages, response_schema, timeout
+                    )
+
+                if result is None:
+                    logger.warning("LLM did not return a valid response")
+                    return {}
+
                 if block:
                     block.update_metadata(
                         llm_tokens_used=total_tokens, llm_request_count=1
                     )
-                return json.loads(response_text)
+                return result
+
+            except BadRequestError as e:
+                # Check if this is a "response_format not supported" error
+                error_msg = str(e).lower()
+                if (
+                    not use_fallback
+                    and "response_format" in error_msg
+                    or "unavailable" in error_msg
+                ):
+                    logger.warning(
+                        f"Structured Outputs not supported by this API, falling back to plain completions: {e}"
+                    )
+                    use_fallback = True
+                    # Retry immediately with fallback
+                    continue
+                else:
+                    logger.error(f"OpenAI inference failed: {e}")
+                    break
+
             except (APITimeoutError, RateLimitError) as e:
                 # Rate limit exceeded
                 if tries == total_tries:

--- a/tests/services/test_openai_fallback.py
+++ b/tests/services/test_openai_fallback.py
@@ -1,0 +1,157 @@
+"""Tests for OpenAI service fallback mechanism.
+
+Tests the fallback behavior when OpenAI-compatible APIs don't support
+Structured Outputs (response_format parameter).
+"""
+
+import json
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pydantic import BaseModel
+
+from marker.services.openai import OpenAIService
+
+
+class MockResponseSchema(BaseModel):
+    """Simple schema for testing JSON parsing."""
+    title: str
+    content: str
+
+
+class TestValidateResponse:
+    """Tests for validate_response() JSON parsing."""
+
+    def test_parses_clean_json(self):
+        """Test parsing clean JSON response."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '{"title": "Test", "content": "Hello"}'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_parses_json_with_markdown_fence(self):
+        """Test parsing JSON wrapped in markdown code fence."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '```json\n{"title": "Test", "content": "Hello"}\n```'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_parses_json_with_generic_fence(self):
+        """Test parsing JSON wrapped in generic code fence."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '```\n{"title": "Test", "content": "Hello"}\n```'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_parses_json_with_whitespace(self):
+        """Test parsing JSON with surrounding whitespace."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '  \n{"title": "Test", "content": "Hello"}\n  '
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_returns_none_for_invalid_json(self):
+        """Test that invalid JSON returns None."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = 'This is not JSON at all'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result is None
+
+    def test_returns_none_for_schema_mismatch(self):
+        """Test that valid JSON not matching schema returns None."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '{"wrong_field": "value"}'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result is None
+
+
+class TestOpenAIServiceConfig:
+    """Tests for OpenAI service configuration."""
+
+    def test_disable_structured_output_default_false(self):
+        """Test that structured output is enabled by default."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        assert service.openai_disable_structured_output is False
+
+    def test_disable_structured_output_can_be_enabled(self):
+        """Test that structured output can be disabled via config."""
+        service = OpenAIService(config={
+            "openai_api_key": "test",
+            "openai_disable_structured_output": True
+        })
+        assert service.openai_disable_structured_output is True
+
+
+class TestOpenAIServiceFallback:
+    """Tests for the fallback mechanism when Structured Outputs fails."""
+
+    @patch('marker.services.openai.openai.OpenAI')
+    def test_uses_structured_output_by_default(self, mock_openai_class):
+        """Test that Structured Outputs is used when not disabled."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"title": "Test", "content": "Hello"}'))]
+        mock_response.usage.total_tokens = 100
+        mock_client.beta.chat.completions.parse.return_value = mock_response
+        
+        service = OpenAIService(config={"openai_api_key": "test"})
+        result = service("Test prompt", None, None, MockResponseSchema)
+        
+        # Should have called the structured output method
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        assert result == {"title": "Test", "content": "Hello"}
+
+    @patch('marker.services.openai.openai.OpenAI')
+    def test_uses_fallback_when_disabled(self, mock_openai_class):
+        """Test that fallback is used when structured output is disabled."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"title": "Test", "content": "Hello"}'))]
+        mock_response.usage.total_tokens = 100
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        service = OpenAIService(config={
+            "openai_api_key": "test",
+            "openai_disable_structured_output": True
+        })
+        result = service("Test prompt", None, None, MockResponseSchema)
+        
+        # Should have called the plain completions method, not structured
+        mock_client.chat.completions.create.assert_called_once()
+        mock_client.beta.chat.completions.parse.assert_not_called()
+        assert result == {"title": "Test", "content": "Hello"}
+
+    @patch('marker.services.openai.openai.OpenAI')
+    def test_fallback_on_bad_request_error(self, mock_openai_class):
+        """Test automatic fallback when BadRequestError indicates unsupported response_format."""
+        from openai import BadRequestError
+        
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        
+        # First call raises BadRequestError
+        mock_client.beta.chat.completions.parse.side_effect = BadRequestError(
+            message="This response_format type is unavailable now",
+            response=MagicMock(status_code=400),
+            body={"error": {"message": "This response_format type is unavailable now"}}
+        )
+        
+        # Fallback call succeeds
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"title": "Fallback", "content": "Works"}'))]
+        mock_response.usage.total_tokens = 100
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        service = OpenAIService(config={"openai_api_key": "test"})
+        result = service("Test prompt", None, None, MockResponseSchema)
+        
+        # Should have tried structured output first, then fallen back
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()
+        assert result == {"title": "Fallback", "content": "Works"}


### PR DESCRIPTION
## Summary

Fixes #985

When using OpenAI-compatible APIs (e.g., DeepSeek) that don't support the `response_format` parameter (Structured Outputs), the LLM step was failing with `response_format type is unavailable` error.

## Changes

- Add `openai_disable_structured_output` config option for users who know their API doesn't support Structured Outputs
- - Implement `validate_response()` method to parse JSON from plain text responses (pattern from `ClaudeService`)
- - Automatically detect when Structured Outputs fails (400 error) and fallback to plain `chat.completions.create()` with schema in the prompt
## Backward Compatibility

Existing OpenAI API users are unaffected - Structured Outputs is still tried first. The fallback only activates when:
1. User explicitly sets `--openai_disable_structured_output`, OR
2. 2. The API returns a 400 error indicating response_format is not supported
## Usage

```shell
# For APIs that don't support Structured Outputs
marker_single document.pdf --use_llm --openai_disable_structured_output \
  --openai_base_url https://api.deepseek.com \
  --openai_model deepseek-reasoner \
  --openai_api_key YOUR_KEY
```