### PR TITLE
feat: Add Groq inference and server LLM support

### DIFF
--- a/marker/scripts/server.py
+++ b/marker/scripts/server.py
@@ -81,6 +81,32 @@ class CommonParams(BaseModel):
             description="The format to output the text in.  Can be 'markdown', 'json', or 'html'.  Defaults to 'markdown'."
         ),
     ] = "markdown"
+    # LLM configuration options (Issue #714)
+    use_llm: Annotated[
+        bool,
+        Field(
+            description="Enable LLM-based processing for improved structure detection."
+        ),
+    ] = False
+    llm_service: Annotated[
+        Optional[str],
+        Field(
+            description="LLM service to use. Examples: marker.services.gemini.GoogleGeminiService, "
+            "marker.services.openai.OpenAIService, marker.services.groq.GroqService"
+        ),
+    ] = None
+    gemini_api_key: Annotated[
+        Optional[str],
+        Field(description="API key for Google Gemini service."),
+    ] = None
+    openai_api_key: Annotated[
+        Optional[str],
+        Field(description="API key for OpenAI service."),
+    ] = None
+    groq_api_key: Annotated[
+        Optional[str],
+        Field(description="API key for Groq service."),
+    ] = None
 
 
 async def _convert_pdf(params: CommonParams):
@@ -138,6 +164,11 @@ async def convert_pdf_upload(
     force_ocr: Optional[bool] = Form(default=False),
     paginate_output: Optional[bool] = Form(default=False),
     output_format: Optional[str] = Form(default="markdown"),
+    use_llm: Optional[bool] = Form(default=False),
+    llm_service: Optional[str] = Form(default=None),
+    gemini_api_key: Optional[str] = Form(default=None),
+    openai_api_key: Optional[str] = Form(default=None),
+    groq_api_key: Optional[str] = Form(default=None),
     file: UploadFile = File(
         ..., description="The PDF file to convert.", media_type="application/pdf"
     ),
@@ -153,6 +184,11 @@ async def convert_pdf_upload(
         force_ocr=force_ocr,
         paginate_output=paginate_output,
         output_format=output_format,
+        use_llm=use_llm,
+        llm_service=llm_service,
+        gemini_api_key=gemini_api_key,
+        openai_api_key=openai_api_key,
+        groq_api_key=groq_api_key,
     )
     results = await _convert_pdf(params)
     os.remove(upload_path)

--- a/marker/services/groq.py
+++ b/marker/services/groq.py
@@ -1,0 +1,53 @@
+"""Groq LLM service for marker.
+
+Groq provides fast inference with an OpenAI-compatible API.
+See https://console.groq.com/docs/quickstart for available models.
+"""
+
+from typing import Annotated
+
+from marker.services.openai import OpenAIService
+
+
+class GroqService(OpenAIService):
+    """
+    Groq LLM service using OpenAI-compatible API.
+    
+    Groq offers extremely fast inference for various LLMs including
+    Llama, Mixtral, and Gemma models.
+    
+    Usage:
+        marker_single document.pdf --use_llm \\
+            --llm_service marker.services.groq.GroqService \\
+            --groq_api_key YOUR_API_KEY \\
+            --groq_model llama-3.3-70b-versatile
+    """
+    
+    groq_api_key: Annotated[
+        str, "The API key for Groq. Get one at https://console.groq.com"
+    ] = None
+    groq_model: Annotated[
+        str, 
+        "The Groq model to use. Options include: llama-3.3-70b-versatile, "
+        "llama-3.1-8b-instant, mixtral-8x7b-32768, gemma2-9b-it"
+    ] = "llama-3.3-70b-versatile"
+    groq_image_format: Annotated[
+        str,
+        "The image format to use for Groq. Use 'png' for better compatibility.",
+    ] = "png"
+    
+    # Groq uses OpenAI-compatible API endpoint
+    openai_base_url: str = "https://api.groq.com/openai/v1"
+    
+    # Groq doesn't support Structured Outputs, so always use fallback
+    openai_disable_structured_output: bool = True
+    
+    def __init__(self, config=None):
+        super().__init__(config)
+        # Map groq-specific config to openai config
+        if self.groq_api_key:
+            self.openai_api_key = self.groq_api_key
+        if self.groq_model:
+            self.openai_model = self.groq_model
+        if self.groq_image_format:
+            self.openai_image_format = self.groq_image_format

--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -1,11 +1,11 @@
 import json
 import time
-from typing import Annotated, List
+from typing import Annotated, List, TypeVar
 
 import openai
 import PIL
 from marker.logger import get_logger
-from openai import APITimeoutError, RateLimitError
+from openai import APITimeoutError, RateLimitError, BadRequestError
 from PIL import Image
 from pydantic import BaseModel
 
@@ -13,6 +13,8 @@ from marker.schema.blocks import Block
 from marker.services import BaseService
 
 logger = get_logger()
+
+T = TypeVar("T")
 
 
 class OpenAIService(BaseService):
@@ -29,6 +31,10 @@ class OpenAIService(BaseService):
         str,
         "The image format to use for the OpenAI-like service. Use 'png' for better compatability",
     ] = "webp"
+    openai_disable_structured_output: Annotated[
+        bool,
+        "Disable Structured Outputs (response_format) for APIs that don't support it (e.g., DeepSeek).",
+    ] = False
 
     def process_images(self, images: List[Image.Image]) -> List[dict]:
         """
@@ -58,6 +64,90 @@ class OpenAIService(BaseService):
             for img in images
         ]
 
+    def validate_response(self, response_text: str, schema: type[T]) -> dict | None:
+        """
+        Parse JSON from plain text response.
+        Used as fallback for APIs that don't support Structured Outputs.
+        """
+        response_text = response_text.strip()
+        if response_text.startswith("```json"):
+            response_text = response_text[7:]
+        if response_text.startswith("```"):
+            response_text = response_text[3:]
+        if response_text.endswith("```"):
+            response_text = response_text[:-3]
+
+        try:
+            # Try to parse as JSON first
+            out_schema = schema.model_validate_json(response_text)
+            return out_schema.model_dump()
+        except Exception:
+            try:
+                # Re-parse with fixed escapes
+                escaped_str = response_text.replace("\\", "\\\\")
+                out_schema = schema.model_validate_json(escaped_str)
+                return out_schema.model_dump()
+            except Exception:
+                return None
+
+    def _call_with_structured_output(
+        self,
+        client: openai.OpenAI,
+        messages: list,
+        response_schema: type[BaseModel],
+        timeout: int,
+    ) -> dict | None:
+        """Call OpenAI API using Structured Outputs (response_format)."""
+        response = client.beta.chat.completions.parse(
+            extra_headers={
+                "X-Title": "Marker",
+                "HTTP-Referer": "https://github.com/datalab-to/marker",
+            },
+            model=self.openai_model,
+            messages=messages,
+            timeout=timeout,
+            response_format=response_schema,
+        )
+        response_text = response.choices[0].message.content
+        return json.loads(response_text), response.usage.total_tokens
+
+    def _call_with_fallback(
+        self,
+        client: openai.OpenAI,
+        messages: list,
+        response_schema: type[BaseModel],
+        timeout: int,
+    ) -> dict | None:
+        """
+        Call OpenAI API using plain chat completions with schema in prompt.
+        Fallback for APIs that don't support Structured Outputs.
+        """
+        schema_example = response_schema.model_json_schema()
+        system_prompt = f"""Follow the instructions given by the user prompt. You must provide your response in JSON format matching this schema:
+
+{json.dumps(schema_example, indent=2)}
+
+Respond only with the JSON, nothing else. Do not include ```json, ```, or any other formatting."""
+
+        # Prepend system message
+        messages_with_system = [
+            {"role": "system", "content": system_prompt},
+            *messages,
+        ]
+
+        response = client.chat.completions.create(
+            extra_headers={
+                "X-Title": "Marker",
+                "HTTP-Referer": "https://github.com/datalab-to/marker",
+            },
+            model=self.openai_model,
+            messages=messages_with_system,
+            timeout=timeout,
+        )
+        response_text = response.choices[0].message.content
+        parsed = self.validate_response(response_text, response_schema)
+        return parsed, response.usage.total_tokens
+
     def __call__(
         self,
         prompt: str,
@@ -86,26 +176,49 @@ class OpenAIService(BaseService):
             }
         ]
 
+        # Track if we should use fallback mode
+        use_fallback = self.openai_disable_structured_output
+
         total_tries = max_retries + 1
         for tries in range(1, total_tries + 1):
             try:
-                response = client.beta.chat.completions.parse(
-                    extra_headers={
-                        "X-Title": "Marker",
-                        "HTTP-Referer": "https://github.com/datalab-to/marker",
-                    },
-                    model=self.openai_model,
-                    messages=messages,
-                    timeout=timeout,
-                    response_format=response_schema,
-                )
-                response_text = response.choices[0].message.content
-                total_tokens = response.usage.total_tokens
+                if use_fallback:
+                    result, total_tokens = self._call_with_fallback(
+                        client, messages, response_schema, timeout
+                    )
+                else:
+                    result, total_tokens = self._call_with_structured_output(
+                        client, messages, response_schema, timeout
+                    )
+
+                if result is None:
+                    logger.warning("LLM did not return a valid response")
+                    return {}
+
                 if block:
                     block.update_metadata(
                         llm_tokens_used=total_tokens, llm_request_count=1
                     )
-                return json.loads(response_text)
+                return result
+
+            except BadRequestError as e:
+                # Check if this is a "response_format not supported" error
+                error_msg = str(e).lower()
+                if (
+                    not use_fallback
+                    and "response_format" in error_msg
+                    or "unavailable" in error_msg
+                ):
+                    logger.warning(
+                        f"Structured Outputs not supported by this API, falling back to plain completions: {e}"
+                    )
+                    use_fallback = True
+                    # Retry immediately with fallback
+                    continue
+                else:
+                    logger.error(f"OpenAI inference failed: {e}")
+                    break
+
             except (APITimeoutError, RateLimitError) as e:
                 # Rate limit exceeded
                 if tries == total_tries:

--- a/tests/services/test_openai_fallback.py
+++ b/tests/services/test_openai_fallback.py
@@ -1,0 +1,157 @@
+"""Tests for OpenAI service fallback mechanism.
+
+Tests the fallback behavior when OpenAI-compatible APIs don't support
+Structured Outputs (response_format parameter).
+"""
+
+import json
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pydantic import BaseModel
+
+from marker.services.openai import OpenAIService
+
+
+class MockResponseSchema(BaseModel):
+    """Simple schema for testing JSON parsing."""
+    title: str
+    content: str
+
+
+class TestValidateResponse:
+    """Tests for validate_response() JSON parsing."""
+
+    def test_parses_clean_json(self):
+        """Test parsing clean JSON response."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '{"title": "Test", "content": "Hello"}'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_parses_json_with_markdown_fence(self):
+        """Test parsing JSON wrapped in markdown code fence."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '```json\n{"title": "Test", "content": "Hello"}\n```'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_parses_json_with_generic_fence(self):
+        """Test parsing JSON wrapped in generic code fence."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '```\n{"title": "Test", "content": "Hello"}\n```'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_parses_json_with_whitespace(self):
+        """Test parsing JSON with surrounding whitespace."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '  \n{"title": "Test", "content": "Hello"}\n  '
+        result = service.validate_response(response, MockResponseSchema)
+        assert result == {"title": "Test", "content": "Hello"}
+
+    def test_returns_none_for_invalid_json(self):
+        """Test that invalid JSON returns None."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = 'This is not JSON at all'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result is None
+
+    def test_returns_none_for_schema_mismatch(self):
+        """Test that valid JSON not matching schema returns None."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        response = '{"wrong_field": "value"}'
+        result = service.validate_response(response, MockResponseSchema)
+        assert result is None
+
+
+class TestOpenAIServiceConfig:
+    """Tests for OpenAI service configuration."""
+
+    def test_disable_structured_output_default_false(self):
+        """Test that structured output is enabled by default."""
+        service = OpenAIService(config={"openai_api_key": "test"})
+        assert service.openai_disable_structured_output is False
+
+    def test_disable_structured_output_can_be_enabled(self):
+        """Test that structured output can be disabled via config."""
+        service = OpenAIService(config={
+            "openai_api_key": "test",
+            "openai_disable_structured_output": True
+        })
+        assert service.openai_disable_structured_output is True
+
+
+class TestOpenAIServiceFallback:
+    """Tests for the fallback mechanism when Structured Outputs fails."""
+
+    @patch('marker.services.openai.openai.OpenAI')
+    def test_uses_structured_output_by_default(self, mock_openai_class):
+        """Test that Structured Outputs is used when not disabled."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"title": "Test", "content": "Hello"}'))]
+        mock_response.usage.total_tokens = 100
+        mock_client.beta.chat.completions.parse.return_value = mock_response
+        
+        service = OpenAIService(config={"openai_api_key": "test"})
+        result = service("Test prompt", None, None, MockResponseSchema)
+        
+        # Should have called the structured output method
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        assert result == {"title": "Test", "content": "Hello"}
+
+    @patch('marker.services.openai.openai.OpenAI')
+    def test_uses_fallback_when_disabled(self, mock_openai_class):
+        """Test that fallback is used when structured output is disabled."""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"title": "Test", "content": "Hello"}'))]
+        mock_response.usage.total_tokens = 100
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        service = OpenAIService(config={
+            "openai_api_key": "test",
+            "openai_disable_structured_output": True
+        })
+        result = service("Test prompt", None, None, MockResponseSchema)
+        
+        # Should have called the plain completions method, not structured
+        mock_client.chat.completions.create.assert_called_once()
+        mock_client.beta.chat.completions.parse.assert_not_called()
+        assert result == {"title": "Test", "content": "Hello"}
+
+    @patch('marker.services.openai.openai.OpenAI')
+    def test_fallback_on_bad_request_error(self, mock_openai_class):
+        """Test automatic fallback when BadRequestError indicates unsupported response_format."""
+        from openai import BadRequestError
+        
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        
+        # First call raises BadRequestError
+        mock_client.beta.chat.completions.parse.side_effect = BadRequestError(
+            message="This response_format type is unavailable now",
+            response=MagicMock(status_code=400),
+            body={"error": {"message": "This response_format type is unavailable now"}}
+        )
+        
+        # Fallback call succeeds
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"title": "Fallback", "content": "Works"}'))]
+        mock_response.usage.total_tokens = 100
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        service = OpenAIService(config={"openai_api_key": "test"})
+        result = service("Test prompt", None, None, MockResponseSchema)
+        
+        # Should have tried structured output first, then fallen back
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()
+        assert result == {"title": "Fallback", "content": "Works"}

--- a/tests/services/test_service_init.py
+++ b/tests/services/test_service_init.py
@@ -6,6 +6,7 @@ from marker.services.ollama import OllamaService
 from marker.services.vertex import GoogleVertexService
 from marker.services.openai import OpenAIService
 from marker.services.azure_openai import AzureOpenAIService
+from marker.services.groq import GroqService
 
 
 @pytest.mark.output_format("markdown")
@@ -83,3 +84,19 @@ def test_llm_openai(pdf_converter: PdfConverter, temp_doc):
 def test_llm_azure_openai(pdf_converter: PdfConverter, temp_doc):
     assert pdf_converter.artifact_dict["llm_service"] is not None
     assert isinstance(pdf_converter.llm_service, AzureOpenAIService)
+
+
+@pytest.mark.output_format("markdown")
+@pytest.mark.config(
+    {
+        "page_range": [0],
+        "use_llm": True,
+        "llm_service": "marker.services.groq.GroqService",
+        "groq_api_key": "test",
+    }
+)
+def test_llm_groq(pdf_converter: PdfConverter, temp_doc):
+    """Test that GroqService initializes correctly (Issue #968)."""
+    assert pdf_converter.artifact_dict["llm_service"] is not None
+    assert isinstance(pdf_converter.llm_service, GroqService)
+


### PR DESCRIPTION
## Summary

This PR addresses two enhancement requests:

### Issue #968: Groq Inference
- Added `GroqService` class extending `OpenAIService`
- Uses Groq's OpenAI-compatible API (`https://api.groq.com/openai/v1`)
- Defaults to `llama-3.3-70b-versatile` model
- Uses fallback mode since Groq doesn't support Structured Outputs

### Issue #714: Server LLM Support  
- Added LLM configuration to `CommonParams`: `use_llm`, `llm_service`, API keys
- Updated `/marker/upload` endpoint with LLM parameters
- Server API now supports Gemini, OpenAI, Groq, and other LLM services

## Usage

### Groq Service
```shell
marker_single document.pdf --use_llm \
  --llm_service marker.services.groq.GroqService \
  --groq_api_key YOUR_API_KEY
```

### Server API with LLM
```json
POST /marker
{
  "filepath": "/path/to/doc.pdf",
  "use_llm": true,
  "llm_service": "marker.services.groq.GroqService",
  "groq_api_key": "YOUR_KEY"
}
```

Fixes #968
Fixes #714