### PR TITLE
Move pre-commit from main to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ markdown2 = "^2.5.2"
 filetype = "^1.2.0"
 google-genai = "^1.0.0"
 anthropic = "^0.46.0"
-pre-commit = "^4.2.0"
 scikit-learn = "^1.6.1"
 
 # Optional dependencies for documents
@@ -61,6 +60,7 @@ lxml = "5.3.0"
 tabulate = "^0.9.0"
 latex2mathml = "^3.77.0"
 playwright = "^1.49.1"
+pre-commit = "^4.2.0"
 
 [tool.poetry.extras]
 full = ["mammoth", "openpyxl", "python-pptx", "ebooklib", "weasyprint"]


### PR DESCRIPTION
## Summary

Move `pre-commit` from `[tool.poetry.dependencies]` to `[tool.poetry.group.dev.dependencies]` in `pyproject.toml`.

`pre-commit` is a development tool and should not be a runtime dependency for end users installing `marker-pdf`.

Closes #935

## Changes

- Removed `pre-commit = "^4.2.0"` from `[tool.poetry.dependencies]`
- Added `pre-commit = "^4.2.0"` to `[tool.poetry.group.dev.dependencies]`
