### PR TITLE
Relax anthropic version pin to allow >=0.46.0,<1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ click = "^8.2.0"
 markdown2 = "^2.5.2"
 filetype = "^1.2.0"
 google-genai = "^1.0.0"
-anthropic = "^0.46.0"
+anthropic = ">=0.46.0,<1.0.0"
 pre-commit = "^4.2.0"
 scikit-learn = "^1.6.1"
 


### PR DESCRIPTION
## Summary

Relax the `anthropic` version constraint from `^0.46.0` (which resolves to `>=0.46.0,<0.47.0`) to `>=0.46.0,<1.0.0`.

The current strict upper bound prevents users from installing `marker-pdf` alongside packages that require newer anthropic versions (e.g., `pydantic-ai` requires `anthropic>=0.52.0`).

The marker code only uses stable API features (`anthropic.Anthropic`, `client.messages.create`, `RateLimitError`, `APITimeoutError`), so newer 0.x versions should be compatible.

Closes #927

## Changes

- Changed `anthropic = "^0.46.0"` to `anthropic = ">=0.46.0,<1.0.0"` in `pyproject.toml`
