### PR TITLE
Relax openai version pin to support >=2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ openpyxl = {version = "^3.1.5", optional = true}
 python-pptx = {version = "^1.0.2", optional = true}
 ebooklib = {version = "^0.18", optional = true}
 weasyprint = {version = "^63.1", optional = true}
-openai = "^1.65.2"
+openai = ">=1.65.2"
 
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"


### PR DESCRIPTION
## Summary

Relax the `openai` version constraint from `^1.65.2` (which resolves to `>=1.65.2,<2.0.0`) to `>=1.65.2`.

The current upper bound prevents users from installing `marker-pdf` alongside other packages that require `openai>=2.0.0`.

I verified that all APIs used by marker (`client.beta.chat.completions.parse`, `AzureOpenAI`, `APITimeoutError`, `RateLimitError`) are fully backward compatible in openai v2.x.

Closes #976

## Changes

- Changed `openai = "^1.65.2"` to `openai = ">=1.65.2"` in `pyproject.toml`
