### PR TITLE
HTML-escape table cell text to prevent < being parsed as tags

### DIFF
--- a/marker/schema/blocks/tablecell.py
+++ b/marker/schema/blocks/tablecell.py
@@ -1,3 +1,4 @@
+import html as html_lib
 from typing import List
 
 from marker.schema import BlockTypes
@@ -33,5 +34,5 @@ class TableCell(Block):
             tag += f' data-block-id="{self.id}"'
         if self.text_lines is None:
             self.text_lines = []
-        text = "<br>".join(self.text_lines)
+        text = "<br>".join(html_lib.escape(line) for line in self.text_lines)
         return f"{tag}>{text}</{tag_cls}>"


### PR DESCRIPTION
## Summary

Fix `<` characters in table cells being parsed as HTML tags by escaping cell text content before embedding it in the HTML representation.

In `TableCell.assemble_html()`, cell text lines were joined directly into HTML without escaping. When a cell contained `<` (e.g., `<LOQ`), it was interpreted as a broken HTML tag by the downstream HTML parser (BeautifulSoup/markdownify), corrupting the table output.

Closes #881

## Changes

- Added `html.escape()` to each text line in `TableCell.assemble_html()` before joining them into the HTML `<td>`/`<th>` element
- This ensures `<`, `>`, and `&` in cell text are properly escaped as `&lt;`, `&gt;`, and `&amp;`

## Example

Before: `<td><LOQ</td>` → parsed as broken HTML tag
After: `<td>&lt;LOQ</td>` → correctly preserved as literal text
