### PR TITLE
Handle Ollama models that return content in thinking field

### DIFF
--- a/marker/services/ollama.py
+++ b/marker/services/ollama.py
@@ -66,6 +66,8 @@ class OllamaService(BaseService):
                 block.update_metadata(llm_request_count=1, llm_tokens_used=total_tokens)
 
             data = response_data["response"]
+            if not data and "thinking" in response_data:
+                data = response_data["thinking"]
             return json.loads(data)
         except Exception as e:
             logger.warning(f"Ollama inference failed: {e}")


### PR DESCRIPTION
## Summary

Fix Ollama inference failure (`Expecting value: line 1 column 1 (char 0)`) when models like `qwen3-vl` return the generated content in the `thinking` field instead of the `response` field.

Some Ollama models with thinking mode enabled (e.g., `qwen3-vl`) place the actual output in the `thinking` field while leaving `response` empty. The current code only reads from `response`, causing `json.loads("")` to fail.

Closes #992

## Changes

- Added a fallback in `OllamaService.__call__()` to read from the `thinking` field when `response` is empty
