### PR TITLE
Deduplicate image description by moving it to img alt text

### DIFF
--- a/marker/renderers/html.py
+++ b/marker/renderers/html.py
@@ -1,3 +1,4 @@
+import html as html_lib
 import textwrap
 
 from PIL import Image
@@ -100,8 +101,20 @@ class HTMLRenderer(BaseRenderer):
                     image = self.extract_image(document, ref_block_id)
                     image_name = f"{ref_block_id.to_path()}.{settings.OUTPUT_IMAGE_FORMAT.lower()}"
                     images[image_name] = image
+                    # Extract description from content and use as alt text to avoid duplication
+                    alt_text = ""
+                    content_soup = BeautifulSoup(content, "html.parser")
+                    desc_tag = content_soup.find("p", attrs={"role": "img"})
+                    if desc_tag:
+                        alt_text = desc_tag.get_text().strip()
+                        # Remove the "Image ... description: " prefix
+                        prefix_end = alt_text.find("description: ")
+                        if prefix_end != -1:
+                            alt_text = alt_text[prefix_end + len("description: "):]
+                        desc_tag.decompose()
+                        content = str(content_soup)
                     element = BeautifulSoup(
-                        f"<p>{content}<img src='{image_name}'></p>", "html.parser"
+                        f"<p>{content}<img src='{image_name}' alt='{html_lib.escape(alt_text, quote=True)}'></p>", "html.parser"
                     )
                     ref.replace_with(self.insert_block_id(element, ref_block_id))
                 else:


### PR DESCRIPTION
## Summary

Fix image descriptions appearing twice in output when `use_llm=True` — once as a separate text paragraph and once embedded with the image.

When the LLM generates an image description, `Picture/Figure.assemble_html()` creates a `<p role='img'>` paragraph with the description. When images are also being extracted, this description paragraph ends up in the output alongside the `<img>` tag, causing duplication.

The fix extracts the description from the `<p role='img'>` tag, moves it into the `<img>` tag's `alt` attribute, and removes the separate paragraph. This produces clean output like:

```markdown
```

Instead of the duplicated:

```markdown

Image ... description: Diagram showing battery modules connected in parallel.
```

Closes #955

## Changes

- Modified `HTMLRenderer.extract_html()` to extract description from `p[role='img']` and use it as the `<img>` alt text
- Description paragraph is removed from content to prevent duplication
- Alt text is properly HTML-escaped
