### PR TITLE
Add `pagination_offset` option to shift paginated page numbers (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Options:
 - `--output_format [markdown|json|html|chunks]`: Specify the format for the output results.
 - `--output_dir PATH`: Directory where output files will be saved. Defaults to the value specified in settings.OUTPUT_DIR.
 - `--paginate_output`: Paginates the output, using `\n\n{PAGE_NUMBER}` followed by `-` * 48, then `\n\n`
+- `--pagination_offset INTEGER`: Shifts the page numbers in paginated output by the given integer (e.g. `--pagination_offset 1` makes the first page show as `{1}` instead of `{0}`). Default is `0`.
 - `--use_llm`: Uses an LLM to improve accuracy.  You will need to configure the LLM backend - see [below](#llm-services).
 - `--force_ocr`: Force OCR processing on the entire document, even for pages that might contain extractable text.  This will also format inline math properly.
 - `--block_correction_prompt`: if LLM mode is active, an optional prompt that will be used to correct the output of marker.  This is useful for custom formatting or logic that you want to apply to the output.

--- a/marker/config/parser.py
+++ b/marker/config/parser.py
@@ -81,6 +81,18 @@ class ConfigParser:
             default=None,
             help="LLM service to use - should be full import path, like marker.services.gemini.GoogleGeminiService",
         )(fn)
+        fn = click.option(
+            "--paginate_output",
+            is_flag=True,
+            default=False,
+            help="Paginates the output, using {PAGE_NUMBER} followed by '-' * 48.",
+        )(fn)
+        fn = click.option(
+            "--pagination_offset",
+            type=int,
+            default=0,
+            help="Integer offset added to each page number when paginating output.",
+        )(fn)
         return fn
 
     def generate_config_dict(self) -> Dict[str, any]:

--- a/marker/renderers/html.py
+++ b/marker/renderers/html.py
@@ -39,6 +39,10 @@ class HTMLRenderer(BaseRenderer):
         bool,
         "Whether to paginate the output.",
     ] = False
+    pagination_offset: Annotated[
+        int,
+        "An integer offset added to each page number when paginating output.",
+    ] = 0
 
     def extract_image(self, document, image_id):
         image_block = document.get_block(image_id)

--- a/marker/renderers/markdown.py
+++ b/marker/renderers/markdown.py
@@ -63,6 +63,7 @@ class Markdownify(MarkdownConverter):
         inline_math_delimiters,
         block_math_delimiters,
         html_tables_in_markdown,
+        pagination_offset=0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -71,11 +72,12 @@ class Markdownify(MarkdownConverter):
         self.inline_math_delimiters = inline_math_delimiters
         self.block_math_delimiters = block_math_delimiters
         self.html_tables_in_markdown = html_tables_in_markdown
+        self.pagination_offset = pagination_offset
 
     def convert_div(self, el, text, parent_tags):
         is_page = el.has_attr("class") and el["class"][0] == "page"
         if self.paginate_output and is_page:
-            page_id = el["data-page-id"]
+            page_id = int(el["data-page-id"]) + self.pagination_offset
             pagination_item = (
                 "\n\n" + "{" + str(page_id) + "}" + self.page_separator + "\n\n"
             )
@@ -292,7 +294,8 @@ class MarkdownRenderer(HTMLRenderer):
             sup_symbol="<sup>",
             inline_math_delimiters=self.inline_math_delimiters,
             block_math_delimiters=self.block_math_delimiters,
-            html_tables_in_markdown=self.html_tables_in_markdown
+            html_tables_in_markdown=self.html_tables_in_markdown,
+            pagination_offset=self.pagination_offset,
         )
 
     def __call__(self, document: Document) -> MarkdownOutput:

--- a/tests/renderers/test_markdown_renderer.py
+++ b/tests/renderers/test_markdown_renderer.py
@@ -33,6 +33,24 @@ def test_markdown_renderer_pagination(pdf_document):
 
 
 @pytest.mark.config({"page_range": [0, 1], "paginate_output": True})
+def test_markdown_renderer_pagination_offset(pdf_document):
+    renderer = MarkdownRenderer({"paginate_output": True, "pagination_offset": 5})
+    md = renderer(pdf_document).markdown
+
+    assert "\n\n{5}-" in md
+    assert "\n\n{6}-" in md
+
+
+@pytest.mark.config({"page_range": [0, 1], "paginate_output": True})
+def test_markdown_renderer_pagination_negative_offset(pdf_document):
+    renderer = MarkdownRenderer({"paginate_output": True, "pagination_offset": -1})
+    md = renderer(pdf_document).markdown
+
+    assert "\n\n{-1}-" in md
+    assert "\n\n{0}-" in md
+
+
+@pytest.mark.config({"page_range": [0, 1], "paginate_output": True})
 def test_markdown_renderer_pagination_blank_last_page(pdf_document):
     # Clear all children and structure from the last page to simulate a blank page
     last_page = pdf_document.pages[-1]


### PR DESCRIPTION
* Add pagination_offset option for paginated markdown output (partially implements https://github.com/datalab-to/marker/issues/1002)
