### PR TITLE
fix: order number and text of section headers by polygon.x_start, ens…

### DIFF
--- a/marker/schema/blocks/sectionheader.py
+++ b/marker/schema/blocks/sectionheader.py
@@ -16,6 +16,8 @@ class SectionHeader(Block):
         if self.ignore_for_output:
             return ""
 
+        child_blocks.sort(key=lambda c: c.polygon.x_start)
+
         if self.html:
             return super().handle_html_output(
                 document, child_blocks, parent_structure, block_config
@@ -25,5 +27,9 @@ class SectionHeader(Block):
             document, child_blocks, parent_structure, block_config
         )
         template = template.replace("\n", " ")
+
+        template = template.replace("</content-ref>", "</content-ref> ")
+        template = " ".join(template.split())
+
         tag = f"h{self.heading_level}" if self.heading_level else "h2"
         return f"<{tag}>{template}</{tag}>"


### PR DESCRIPTION
### Description
In some PDFs (especially those with OCR layers), section numbers were positioned after the heading text in the output. This PR ensures that header elements are ordered by `polygon.x_start` to maintain the correct reading order.

(Note: This is the first of three independent PRs to improve `marker`.)
