### PR TITLE
fix(gemini): update deafault model

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [below](#benchmarks) for detailed speed and accuracy benchmarks, and instruc
 
 ## Hybrid Mode
 
-For the highest accuracy, pass the `--use_llm` flag to use an LLM alongside marker.  This will do things like merge tables across pages, handle inline math, format tables properly, and extract values from forms.  It can use any gemini or ollama model.  By default, it uses `gemini-2.0-flash`.  See [below](#llm-services) for details.
+For the highest accuracy, pass the `--use_llm` flag to use an LLM alongside marker.  This will do things like merge tables across pages, handle inline math, format tables properly, and extract values from forms.  It can use any gemini or ollama model.  By default, it uses `gemini-3-flash-preview`.  See [below](#llm-services) for details.
 
 Here is a table benchmark comparing marker, gemini flash alone, and marker with use_llm:
 

--- a/benchmarks/table/gemini.py
+++ b/benchmarks/table/gemini.py
@@ -35,7 +35,7 @@ def gemini_table_rec(image: Image.Image):
     image.save(image_bytes, format="PNG")
 
     responses = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-3-flash-preview",
         contents=[types.Part.from_bytes(data=image_bytes.getvalue(), mime_type="image/png"), prompt],  # According to gemini docs, it performs better if the image is the first element
         config={
             "temperature": 0,

--- a/marker/services/gemini.py
+++ b/marker/services/gemini.py
@@ -20,7 +20,7 @@ logger = get_logger()
 class BaseGeminiService(BaseService):
     gemini_model_name: Annotated[
         str, "The name of the Google model to use for the service."
-    ] = "gemini-2.0-flash"
+    ] = "gemini-3-flash-preview"
     thinking_budget: Annotated[
         int, "The thinking token budget to use for the service."
     ] = None


### PR DESCRIPTION
## Background

Google AI Studio API Error:

```shell
404 NOT_FOUND — This model models/gemini-2.0-flash is no longer available to new users. Please update your code to use a newer model.
```

## Solution

Update default gemini model to `gemini-3-flash-preview`.