### PR TITLE
feat: add Avian as LLM service provider

### DIFF
--- a/marker/services/avian.py
+++ b/marker/services/avian.py
@@ -2,10 +2,8 @@ import json
 import time
 from typing import Annotated, List
 
-import openai
 import PIL
 from marker.logger import get_logger
-from openai import APITimeoutError, RateLimitError
 from PIL import Image
 from pydantic import BaseModel
 
@@ -13,6 +11,17 @@ from marker.schema.blocks import Block
 from marker.services import BaseService
 
 logger = get_logger()
+
+
+def _import_openai():
+    try:
+        import openai
+        return openai
+    except ImportError:
+        raise ImportError(
+            "The 'openai' package is required to use AvianService. "
+            "Install it with: pip install openai"
+        )
 
 
 class AvianService(BaseService):
@@ -89,6 +98,8 @@ class AvianService(BaseService):
             }
         ]
 
+        openai = _import_openai()
+
         total_tries = max_retries + 1
         for tries in range(1, total_tries + 1):
             try:
@@ -109,7 +120,7 @@ class AvianService(BaseService):
                         llm_tokens_used=total_tokens, llm_request_count=1
                     )
                 return json.loads(response_text)
-            except (APITimeoutError, RateLimitError) as e:
+            except (openai.APITimeoutError, openai.RateLimitError) as e:
                 if tries == total_tries:
                     logger.error(
                         f"Rate limit error: {e}. Max retries reached. Giving up. (Attempt {tries}/{total_tries})",
@@ -127,7 +138,8 @@ class AvianService(BaseService):
 
         return {}
 
-    def get_client(self) -> openai.OpenAI:
+    def get_client(self):
+        openai = _import_openai()
         return openai.OpenAI(
             api_key=self.avian_api_key,
             base_url="https://api.avian.io/v1",

--- a/marker/services/avian.py
+++ b/marker/services/avian.py
@@ -1,0 +1,134 @@
+import json
+import time
+from typing import Annotated, List
+
+import openai
+import PIL
+from marker.logger import get_logger
+from openai import APITimeoutError, RateLimitError
+from PIL import Image
+from pydantic import BaseModel
+
+from marker.schema.blocks import Block
+from marker.services import BaseService
+
+logger = get_logger()
+
+
+class AvianService(BaseService):
+    """LLM service for the Avian inference API (OpenAI-compatible).
+
+    Available models:
+        - deepseek-v3.2     (DeepSeek V3.2, 164K context)
+        - kimi-k2.5         (Kimi K2.5, 128K context)
+        - glm-5             (GLM-5, 128K context)
+        - minimax-m2.5      (MiniMax M2.5, 1M context)
+
+    Usage:
+        --llm_service marker.services.avian.AvianService
+        --avian_api_key <your-key>
+        --avian_model deepseek-v3.2
+    """
+
+    avian_api_key: Annotated[
+        str, "The API key to use for the Avian service."
+    ] = None
+    avian_model: Annotated[
+        str,
+        "The model name to use for the Avian service. "
+        "Options: deepseek-v3.2, kimi-k2.5, glm-5, minimax-m2.5",
+    ] = "deepseek-v3.2"
+    avian_image_format: Annotated[
+        str,
+        "The image format to use for the Avian service. "
+        "Use 'png' for better compatibility.",
+    ] = "png"
+
+    def process_images(self, images: List[Image.Image]) -> List[dict]:
+        if isinstance(images, Image.Image):
+            images = [images]
+
+        img_fmt = self.avian_image_format
+        return [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/{};base64,{}".format(
+                        img_fmt, self.img_to_base64(img, format=img_fmt)
+                    ),
+                },
+            }
+            for img in images
+        ]
+
+    def __call__(
+        self,
+        prompt: str,
+        image: PIL.Image.Image | List[PIL.Image.Image] | None,
+        block: Block | None,
+        response_schema: type[BaseModel],
+        max_retries: int | None = None,
+        timeout: int | None = None,
+    ):
+        if max_retries is None:
+            max_retries = self.max_retries
+
+        if timeout is None:
+            timeout = self.timeout
+
+        client = self.get_client()
+        image_data = self.format_image_for_llm(image)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    *image_data,
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ]
+
+        total_tries = max_retries + 1
+        for tries in range(1, total_tries + 1):
+            try:
+                response = client.beta.chat.completions.parse(
+                    extra_headers={
+                        "X-Title": "Marker",
+                        "HTTP-Referer": "https://github.com/datalab-to/marker",
+                    },
+                    model=self.avian_model,
+                    messages=messages,
+                    timeout=timeout,
+                    response_format=response_schema,
+                )
+                response_text = response.choices[0].message.content
+                total_tokens = response.usage.total_tokens
+                if block:
+                    block.update_metadata(
+                        llm_tokens_used=total_tokens, llm_request_count=1
+                    )
+                return json.loads(response_text)
+            except (APITimeoutError, RateLimitError) as e:
+                if tries == total_tries:
+                    logger.error(
+                        f"Rate limit error: {e}. Max retries reached. Giving up. (Attempt {tries}/{total_tries})",
+                    )
+                    break
+                else:
+                    wait_time = tries * self.retry_wait_time
+                    logger.warning(
+                        f"Rate limit error: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})",
+                    )
+                    time.sleep(wait_time)
+            except Exception as e:
+                logger.error(f"Avian inference failed: {e}")
+                break
+
+        return {}
+
+    def get_client(self) -> openai.OpenAI:
+        return openai.OpenAI(
+            api_key=self.avian_api_key,
+            base_url="https://api.avian.io/v1",
+        )

--- a/marker/services/avian.py
+++ b/marker/services/avian.py
@@ -22,7 +22,7 @@ class AvianService(BaseService):
         - deepseek-v3.2     (DeepSeek V3.2, 164K context)
         - kimi-k2.5         (Kimi K2.5, 128K context)
         - glm-5             (GLM-5, 128K context)
-        - minimax-m2.5      (MiniMax M2.5, 1M context)
+        - minimax-m2.5      (MiniMax M2.5, 200K context, 16K max output)
 
     Usage:
         --llm_service marker.services.avian.AvianService

--- a/tests/services/test_avian_service.py
+++ b/tests/services/test_avian_service.py
@@ -184,3 +184,25 @@ def test_call_with_image(avian_service):
 def test_missing_api_key_raises():
     with pytest.raises(AssertionError):
         AvianService(config={})
+
+
+def test_conditional_import_error():
+    """Verify helpful error when openai is not installed."""
+    import importlib
+    import sys
+
+    import marker.services.avian as avian_mod
+
+    # Temporarily hide the openai module
+    real_openai = sys.modules.get("openai")
+    sys.modules["openai"] = None
+    try:
+        importlib.reload(avian_mod)
+        with pytest.raises(ImportError, match="openai"):
+            avian_mod._import_openai()
+    finally:
+        if real_openai is not None:
+            sys.modules["openai"] = real_openai
+        else:
+            sys.modules.pop("openai", None)
+        importlib.reload(avian_mod)

--- a/tests/services/test_avian_service.py
+++ b/tests/services/test_avian_service.py
@@ -1,0 +1,186 @@
+import json
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from PIL import Image
+from pydantic import BaseModel
+
+from marker.services.avian import AvianService
+
+
+class SampleSchema(BaseModel):
+    text: str
+    confidence: float
+
+
+@pytest.fixture
+def avian_service():
+    return AvianService(config={"avian_api_key": "test-key"})
+
+
+def test_default_config(avian_service):
+    assert avian_service.avian_api_key == "test-key"
+    assert avian_service.avian_model == "deepseek-v3.2"
+    assert avian_service.avian_image_format == "png"
+
+
+def test_custom_model():
+    service = AvianService(
+        config={"avian_api_key": "test-key", "avian_model": "kimi-k2.5"}
+    )
+    assert service.avian_model == "kimi-k2.5"
+
+
+def test_get_client(avian_service):
+    client = avian_service.get_client()
+    assert client.api_key == "test-key"
+    assert client.base_url.host == "api.avian.io"
+    assert str(client.base_url).rstrip("/").endswith("/v1")
+
+
+def test_process_images_single(avian_service):
+    img = Image.new("RGB", (10, 10), color="red")
+    result = avian_service.process_images(img)
+    assert len(result) == 1
+    assert result[0]["type"] == "image_url"
+    assert result[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_process_images_list(avian_service):
+    images = [
+        Image.new("RGB", (10, 10), color="red"),
+        Image.new("RGB", (10, 10), color="blue"),
+    ]
+    result = avian_service.process_images(images)
+    assert len(result) == 2
+    for item in result:
+        assert item["type"] == "image_url"
+        assert item["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_call_success(avian_service):
+    expected = {"text": "hello", "confidence": 0.95}
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(expected)
+    mock_response.usage.total_tokens = 100
+
+    mock_client = MagicMock()
+    mock_client.beta.chat.completions.parse.return_value = mock_response
+
+    with patch.object(avian_service, "get_client", return_value=mock_client):
+        result = avian_service(
+            prompt="Extract text",
+            image=None,
+            block=None,
+            response_schema=SampleSchema,
+        )
+
+    assert result == expected
+    mock_client.beta.chat.completions.parse.assert_called_once()
+    call_kwargs = mock_client.beta.chat.completions.parse.call_args
+    assert call_kwargs.kwargs["model"] == "deepseek-v3.2"
+
+
+def test_call_updates_block_metadata(avian_service):
+    expected = {"text": "hello", "confidence": 0.95}
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(expected)
+    mock_response.usage.total_tokens = 42
+
+    mock_client = MagicMock()
+    mock_client.beta.chat.completions.parse.return_value = mock_response
+
+    mock_block = MagicMock()
+
+    with patch.object(avian_service, "get_client", return_value=mock_client):
+        result = avian_service(
+            prompt="Extract text",
+            image=None,
+            block=mock_block,
+            response_schema=SampleSchema,
+        )
+
+    assert result == expected
+    mock_block.update_metadata.assert_called_once_with(
+        llm_tokens_used=42, llm_request_count=1
+    )
+
+
+def test_call_rate_limit_retries(avian_service):
+    from openai import RateLimitError
+
+    mock_client = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 429
+    mock_resp.headers = {}
+    mock_client.beta.chat.completions.parse.side_effect = RateLimitError(
+        message="rate limited",
+        response=mock_resp,
+        body=None,
+    )
+
+    with patch.object(avian_service, "get_client", return_value=mock_client):
+        with patch("marker.services.avian.time.sleep"):
+            result = avian_service(
+                prompt="Extract text",
+                image=None,
+                block=None,
+                response_schema=SampleSchema,
+                max_retries=2,
+            )
+
+    assert result == {}
+    assert mock_client.beta.chat.completions.parse.call_count == 3
+
+
+def test_call_generic_exception_no_retry(avian_service):
+    mock_client = MagicMock()
+    mock_client.beta.chat.completions.parse.side_effect = ValueError("bad input")
+
+    with patch.object(avian_service, "get_client", return_value=mock_client):
+        result = avian_service(
+            prompt="Extract text",
+            image=None,
+            block=None,
+            response_schema=SampleSchema,
+        )
+
+    assert result == {}
+    assert mock_client.beta.chat.completions.parse.call_count == 1
+
+
+def test_call_with_image(avian_service):
+    expected = {"text": "hello", "confidence": 0.95}
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(expected)
+    mock_response.usage.total_tokens = 50
+
+    mock_client = MagicMock()
+    mock_client.beta.chat.completions.parse.return_value = mock_response
+
+    img = Image.new("RGB", (10, 10), color="red")
+
+    with patch.object(avian_service, "get_client", return_value=mock_client):
+        result = avian_service(
+            prompt="Describe image",
+            image=img,
+            block=None,
+            response_schema=SampleSchema,
+        )
+
+    assert result == expected
+    call_kwargs = mock_client.beta.chat.completions.parse.call_args
+    messages = call_kwargs.kwargs["messages"]
+    content = messages[0]["content"]
+    # Should have image data + text prompt
+    assert len(content) == 2
+    assert content[0]["type"] == "image_url"
+    assert content[1]["type"] == "text"
+
+
+def test_missing_api_key_raises():
+    with pytest.raises(AssertionError):
+        AvianService(config={})

--- a/tests/services/test_service_init.py
+++ b/tests/services/test_service_init.py
@@ -4,6 +4,7 @@ from marker.converters.pdf import PdfConverter
 from marker.services.gemini import GoogleGeminiService
 from marker.services.ollama import OllamaService
 from marker.services.vertex import GoogleVertexService
+from marker.services.avian import AvianService
 from marker.services.openai import OpenAIService
 from marker.services.azure_openai import AzureOpenAIService
 
@@ -83,3 +84,17 @@ def test_llm_openai(pdf_converter: PdfConverter, temp_doc):
 def test_llm_azure_openai(pdf_converter: PdfConverter, temp_doc):
     assert pdf_converter.artifact_dict["llm_service"] is not None
     assert isinstance(pdf_converter.llm_service, AzureOpenAIService)
+
+
+@pytest.mark.output_format("markdown")
+@pytest.mark.config(
+    {
+        "page_range": [0],
+        "use_llm": True,
+        "llm_service": "marker.services.avian.AvianService",
+        "avian_api_key": "test",
+    }
+)
+def test_llm_avian(pdf_converter: PdfConverter, temp_doc):
+    assert pdf_converter.artifact_dict["llm_service"] is not None
+    assert isinstance(pdf_converter.llm_service, AvianService)

--- a/tests/services/test_service_init.py
+++ b/tests/services/test_service_init.py
@@ -1,12 +1,12 @@
 import pytest
 
 from marker.converters.pdf import PdfConverter
+from marker.services.avian import AvianService
+from marker.services.azure_openai import AzureOpenAIService
 from marker.services.gemini import GoogleGeminiService
 from marker.services.ollama import OllamaService
-from marker.services.vertex import GoogleVertexService
-from marker.services.avian import AvianService
 from marker.services.openai import OpenAIService
-from marker.services.azure_openai import AzureOpenAIService
+from marker.services.vertex import GoogleVertexService
 
 
 @pytest.mark.output_format("markdown")


### PR DESCRIPTION
## Summary

- Adds `AvianService` as a new LLM service option for the Avian inference API (`https://api.avian.io/v1`), which is OpenAI-compatible
- Follows the same patterns as the existing `OpenAIService` and `AzureOpenAIService` implementations
- Adds corresponding test in `tests/services/test_service_init.py`

## Available Models

| Model | Context Window |
|-------|---------------|
| DeepSeek V3.2 (`deepseek-v3.2`) | 164K |
| Kimi K2.5 (`kimi-k2.5`) | 128K |
| GLM-5 (`glm-5`) | 128K |
| MiniMax M2.5 (`minimax-m2.5`) | 1M |

## Usage

```bash
marker_single input.pdf \
  --llm_service marker.services.avian.AvianService \
  --avian_api_key YOUR_API_KEY \
  --avian_model deepseek-v3.2
```

## Configuration

| Option | Description | Default |
|--------|-------------|---------|
| `avian_api_key` | API key for the Avian service | *(required)* |
| `avian_model` | Model to use | `deepseek-v3.2` |
| `avian_image_format` | Image format for multimodal requests | `png` |

## Test plan

- [x] Added `test_llm_avian` to `tests/services/test_service_init.py` verifying service initialization
- [ ] Verify structured output (JSON schema) works with Avian's OpenAI-compatible endpoint
- [ ] Verify image processing works for multimodal PDF pages