### PR TITLE
fix: sanitize upload filename to prevent path traversal and concurrent collisions

### DIFF
--- a/marker/scripts/server.py
+++ b/marker/scripts/server.py
@@ -2,6 +2,7 @@ import traceback
 
 import click
 import os
+import uuid
 
 from pydantic import BaseModel, Field
 from starlette.responses import HTMLResponse
@@ -14,7 +15,7 @@ from contextlib import asynccontextmanager
 from typing import Optional, Annotated
 import io
 
-from fastapi import FastAPI, Form, File, UploadFile
+from fastapi import FastAPI, Form, File, HTTPException, UploadFile
 from marker.converters.pdf import PdfConverter
 from marker.models import create_model_dict
 from marker.settings import settings
@@ -142,21 +143,33 @@ async def convert_pdf_upload(
         ..., description="The PDF file to convert.", media_type="application/pdf"
     ),
 ):
-    upload_path = os.path.join(UPLOAD_DIRECTORY, file.filename)
-    with open(upload_path, "wb+") as upload_file:
-        file_contents = await file.read()
-        upload_file.write(file_contents)
+    safe_name = f"{uuid.uuid4().hex}_{os.path.basename(file.filename or 'upload')}"
+    upload_path = os.path.join(UPLOAD_DIRECTORY, safe_name)
+    upload_dir = os.path.realpath(UPLOAD_DIRECTORY)
+    resolved = os.path.realpath(upload_path)
 
-    params = CommonParams(
-        filepath=upload_path,
-        page_range=page_range,
-        force_ocr=force_ocr,
-        paginate_output=paginate_output,
-        output_format=output_format,
-    )
-    results = await _convert_pdf(params)
-    os.remove(upload_path)
-    return results
+    try:
+        if os.path.commonpath([upload_dir, resolved]) != upload_dir:
+            raise HTTPException(status_code=400, detail="Invalid filename")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid filename") from exc
+
+    try:
+        with open(resolved, "wb+") as upload_file:
+            file_contents = await file.read()
+            upload_file.write(file_contents)
+
+        params = CommonParams(
+            filepath=resolved,
+            page_range=page_range,
+            force_ocr=force_ocr,
+            paginate_output=paginate_output,
+            output_format=output_format,
+        )
+        return await _convert_pdf(params)
+    finally:
+        if os.path.exists(resolved):
+            os.remove(resolved)
 
 
 @click.command()

--- a/tests/scripts/test_server_upload.py
+++ b/tests/scripts/test_server_upload.py
@@ -1,0 +1,140 @@
+import asyncio
+import importlib
+import io
+import shutil
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+from starlette.datastructures import UploadFile
+
+
+def load_server_module(monkeypatch):
+    fake_config_parser = types.ModuleType("marker.config.parser")
+    fake_config_parser.ConfigParser = object
+
+    fake_output = types.ModuleType("marker.output")
+    fake_output.text_from_rendered = lambda rendered: ("", None, {})
+
+    fake_pdf_converter = types.ModuleType("marker.converters.pdf")
+    fake_pdf_converter.PdfConverter = object
+
+    fake_models = types.ModuleType("marker.models")
+    fake_models.create_model_dict = lambda: {}
+
+    fake_settings = types.ModuleType("marker.settings")
+    fake_settings.settings = SimpleNamespace(
+        OUTPUT_IMAGE_FORMAT="PNG",
+        OUTPUT_ENCODING="utf-8",
+    )
+
+    monkeypatch.setitem(sys.modules, "marker.config.parser", fake_config_parser)
+    monkeypatch.setitem(sys.modules, "marker.output", fake_output)
+    monkeypatch.setitem(sys.modules, "marker.converters.pdf", fake_pdf_converter)
+    monkeypatch.setitem(sys.modules, "marker.models", fake_models)
+    monkeypatch.setitem(sys.modules, "marker.settings", fake_settings)
+    monkeypatch.delitem(sys.modules, "marker.scripts.server", raising=False)
+
+    return importlib.import_module("marker.scripts.server")
+
+
+def make_upload_dir(name: str) -> Path:
+    upload_dir = Path(__file__).with_name(name)
+    if upload_dir.exists():
+        shutil.rmtree(upload_dir)
+    upload_dir.mkdir()
+    return upload_dir
+
+
+def test_convert_pdf_upload_sanitizes_filename_and_keeps_path_inside_upload_dir(
+    monkeypatch,
+):
+    server = load_server_module(monkeypatch)
+    upload_dir = make_upload_dir("_tmp_uploads_sanitized")
+    monkeypatch.setattr(server, "UPLOAD_DIRECTORY", str(upload_dir))
+    monkeypatch.setattr(
+        server.uuid, "uuid4", lambda: UUID("11111111-1111-1111-1111-111111111111")
+    )
+
+    captured = {}
+
+    async def fake_convert(params):
+        captured["filepath"] = params.filepath
+        return {"success": True}
+
+    monkeypatch.setattr(server, "_convert_pdf", fake_convert)
+
+    try:
+        upload = UploadFile(filename="../../etc/passwd.pdf", file=io.BytesIO(b"pdf"))
+        result = asyncio.run(
+            server.convert_pdf_upload(
+                page_range=None,
+                force_ocr=False,
+                paginate_output=False,
+                output_format="markdown",
+                file=upload,
+            )
+        )
+
+        assert result == {"success": True}
+        assert Path(captured["filepath"]).parent == upload_dir
+        assert (
+            Path(captured["filepath"]).name
+            == "11111111111111111111111111111111_passwd.pdf"
+        )
+        assert not Path(captured["filepath"]).exists()
+    finally:
+        shutil.rmtree(upload_dir)
+
+
+def test_convert_pdf_upload_uses_unique_paths_for_same_filename(monkeypatch):
+    server = load_server_module(monkeypatch)
+    upload_dir = make_upload_dir("_tmp_uploads_unique")
+    monkeypatch.setattr(server, "UPLOAD_DIRECTORY", str(upload_dir))
+
+    ids = iter(
+        [
+            UUID("11111111-1111-1111-1111-111111111111"),
+            UUID("22222222-2222-2222-2222-222222222222"),
+        ]
+    )
+    monkeypatch.setattr(server.uuid, "uuid4", lambda: next(ids))
+
+    seen_paths = []
+
+    async def fake_convert(params):
+        seen_paths.append(params.filepath)
+        return {"success": True}
+
+    monkeypatch.setattr(server, "_convert_pdf", fake_convert)
+
+    try:
+        first = UploadFile(filename="report.pdf", file=io.BytesIO(b"first"))
+        second = UploadFile(filename="report.pdf", file=io.BytesIO(b"second"))
+
+        asyncio.run(
+            server.convert_pdf_upload(
+                page_range=None,
+                force_ocr=False,
+                paginate_output=False,
+                output_format="markdown",
+                file=first,
+            )
+        )
+        asyncio.run(
+            server.convert_pdf_upload(
+                page_range=None,
+                force_ocr=False,
+                paginate_output=False,
+                output_format="markdown",
+                file=second,
+            )
+        )
+
+        assert len(seen_paths) == 2
+        assert len(set(seen_paths)) == 2
+        assert all(Path(path).parent == upload_dir for path in seen_paths)
+    finally:
+        shutil.rmtree(upload_dir)


### PR DESCRIPTION
Fixes #1017
Fixes #1018

Security fix: the upload endpoint trusts the multipart filename directly, allowing path traversal. Also, concurrent uploads with the same filename race on the same file.

This fix uses UUID-based unique filenames with basename sanitization and path validation.