### PR TITLE
Add --llm_image_context for context-aware image descriptions

### DIFF
--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -32,6 +32,7 @@ from marker.processors.list import ListProcessor
 from marker.processors.llm.llm_complex import LLMComplexRegionProcessor
 from marker.processors.llm.llm_form import LLMFormProcessor
 from marker.processors.llm.llm_image_description import LLMImageDescriptionProcessor
+from marker.processors.llm.llm_image_context import LLMImageContextDescriptionProcessor
 from marker.processors.llm.llm_table import LLMTableProcessor
 from marker.processors.page_header import PageHeaderProcessor
 from marker.processors.reference import ReferenceProcessor
@@ -92,6 +93,7 @@ class PdfConverter(BaseConverter):
         TextProcessor,
         LLMComplexRegionProcessor,
         LLMImageDescriptionProcessor,
+        LLMImageContextDescriptionProcessor,
         LLMEquationProcessor,
         LLMHandwritingProcessor,
         LLMMathBlockProcessor,
@@ -135,7 +137,7 @@ class PdfConverter(BaseConverter):
         if llm_service:
             llm_service_cls = strings_to_classes([llm_service])[0]
             llm_service = self.resolve_dependencies(llm_service_cls)
-        elif config.get("use_llm", False):
+        elif config.get("use_llm", False) or config.get("llm_image_context", False):
             llm_service = self.resolve_dependencies(self.default_llm_service)
 
         # Inject llm service into artifact_dict so it can be picked up by processors, etc.

--- a/marker/processors/llm/__init__.py
+++ b/marker/processors/llm/__init__.py
@@ -51,17 +51,25 @@ class BaseLLMProcessor(BaseProcessor):
         bool,
         "Whether to use the LLM model.",
     ] = False
+    llm_image_context: Annotated[
+        bool,
+        "Whether to use the context-aware image-description LLM processor (orthogonal to use_llm).",
+    ] = False
     disable_tqdm: Annotated[
         bool,
         "Whether to disable the tqdm progress bar.",
     ] = False
     block_types = None
 
+    @property
+    def llm_enabled(self) -> bool:
+        return self.use_llm or self.llm_image_context
+
     def __init__(self, llm_service: BaseService, config=None):
         super().__init__(config)
 
         self.llm_service = None
-        if not self.use_llm:
+        if not self.llm_enabled:
             return
 
         self.llm_service = llm_service

--- a/marker/processors/llm/llm_image_context.py
+++ b/marker/processors/llm/llm_image_context.py
@@ -1,0 +1,132 @@
+from typing import Annotated, List
+
+from pydantic import BaseModel
+
+from marker.processors.llm import BaseLLMSimpleBlockProcessor, BlockData, PromptData
+from marker.schema import BlockTypes
+from marker.schema.document import Document
+from marker.settings import settings
+
+
+class LLMImageContextDescriptionProcessor(BaseLLMSimpleBlockProcessor):
+    """
+    Generate image descriptions that incorporate page context — the page's
+    extracted markdown text and the page image are sent alongside the figure
+    image, so the LLM can describe the figure with awareness of its
+    surrounding content. Produces a short caption (used as alt text) and a
+    long description (rendered as a hidden HTML comment).
+
+    Independent of --use_llm's existing LLMImageDescriptionProcessor and
+    compatible with extract_images either on or off.
+    """
+    block_types = (
+        BlockTypes.Picture,
+        BlockTypes.Figure,
+    )
+    llm_image_context: Annotated[
+        bool,
+        "Enable context-aware LLM image descriptions (sends page markdown + page image alongside the figure).",
+    ] = False
+    image_context_prompt: Annotated[
+        str,
+        "The prompt used for context-aware image descriptions.",
+    ] = """You are a document analysis expert. You are given three things:
+1. The extracted text of a page, in markdown form. The figure you must describe is referenced inline by its filename `{filename}`.
+2. An image of the full page (first attached image).
+3. An image of just the figure to describe (second attached image).
+
+Your task: write a description of the figure in the context of the page.
+- Be faithful to what is actually shown. Include all pertinent numeric data, axis labels, legends, titles, and visible text.
+- Tie the figure to the surrounding text on the page when relevant (e.g. "supports the section's claim that X").
+- Do not invent details that are not present in the image.
+
+Return two fields:
+- `short_caption`: a single-sentence alt-text-style caption (≤ 140 characters).
+- `long_description`: a complete description suitable for a text-only model that cannot see the image. Include the relevant page context.
+
+**Page markdown:**
+```
+{page_markdown}
+```
+"""
+
+    def inference_blocks(self, document: Document) -> List[BlockData]:
+        if not self.llm_image_context:
+            return []
+        return super().inference_blocks(document)
+
+    def _build_page_markdown(self, document: Document, page, target_block) -> str:
+        """
+        Walk the page's structure in order, emitting raw text of each block.
+        Where the target figure sits, emit a markdown image reference using
+        the deterministic output filename so the LLM has an explicit anchor.
+        """
+        image_ext = settings.OUTPUT_IMAGE_FORMAT.lower()
+        parts = []
+        structure = page.structure or []
+        for block_id in structure:
+            block = document.get_block(block_id)
+            if block is None or block.ignore_for_output:
+                continue
+            if block.id == target_block.id:
+                parts.append(f"![]({block.id.to_path()}.{image_ext})")
+                continue
+            if block.block_type in (BlockTypes.Picture, BlockTypes.Figure):
+                parts.append(f"![]({block.id.to_path()}.{image_ext})")
+                continue
+            text = block.raw_text(document).strip()
+            if text:
+                parts.append(text)
+        return "\n\n".join(parts)
+
+    def block_prompts(self, document: Document) -> List[PromptData]:
+        prompt_data: List[PromptData] = []
+        image_ext = settings.OUTPUT_IMAGE_FORMAT.lower()
+        for block_data in self.inference_blocks(document):
+            block = block_data["block"]
+            page = block_data["page"]
+
+            page_markdown = self._build_page_markdown(document, page, block)
+            filename = f"{block.id.to_path()}.{image_ext}"
+            prompt = self.image_context_prompt.format(
+                filename=filename, page_markdown=page_markdown
+            )
+
+            page_image = page.get_image(highres=False)
+            figure_image = self.extract_image(document, block)
+
+            prompt_data.append(
+                {
+                    "prompt": prompt,
+                    "image": [page_image, figure_image],
+                    "block": block,
+                    "schema": ImageContextSchema,
+                    "page": page,
+                }
+            )
+
+        return prompt_data
+
+    def rewrite_block(
+        self, response: dict, prompt_data: PromptData, document: Document
+    ):
+        block = prompt_data["block"]
+
+        if not response or "long_description" not in response:
+            block.update_metadata(llm_error_count=1)
+            return
+
+        long_description = response.get("long_description", "")
+        short_caption = response.get("short_caption", "")
+
+        if len(long_description) < 10:
+            block.update_metadata(llm_error_count=1)
+            return
+
+        block.long_description = long_description
+        block.short_caption = short_caption or long_description[:140]
+
+
+class ImageContextSchema(BaseModel):
+    short_caption: str
+    long_description: str

--- a/marker/processors/llm/llm_image_description.py
+++ b/marker/processors/llm/llm_image_description.py
@@ -14,6 +14,10 @@ class LLMImageDescriptionProcessor(BaseLLMSimpleBlockProcessor):
         BlockTypes.Figure,
     )
     extract_images: Annotated[bool, "Extract images from the document."] = True
+    llm_image_context: Annotated[
+        bool,
+        "If enabled, defer to LLMImageContextDescriptionProcessor and skip this processor.",
+    ] = False
     image_description_prompt: Annotated[
         str,
         "The prompt to use for generating image descriptions.",
@@ -40,6 +44,8 @@ In this figure, a bar chart titled "Fruit Preference Survey" is showing the numb
 """
 
     def inference_blocks(self, document: Document) -> List[BlockData]:
+        if self.llm_image_context:
+            return []
         blocks = super().inference_blocks(document)
         if self.extract_images:
             return []

--- a/marker/processors/llm/llm_meta.py
+++ b/marker/processors/llm/llm_meta.py
@@ -26,7 +26,7 @@ class LLMSimpleBlockMetaProcessor(BaseLLMProcessor):
         self.processors = processor_lst
 
     def __call__(self, document: Document):
-        if not self.use_llm or self.llm_service is None:
+        if not self.llm_enabled or self.llm_service is None:
             return
 
         total = sum(

--- a/marker/renderers/html.py
+++ b/marker/renderers/html.py
@@ -96,17 +96,29 @@ class HTMLRenderer(BaseRenderer):
                     break
 
             if ref_block_id.block_type in self.image_blocks:
+                block = document.get_block(ref_block_id)
+                short_caption = getattr(block, "short_caption", None) or ""
+                long_description = getattr(block, "long_description", None)
+                # Escape quotes for safe attribute embedding
+                alt_attr = short_caption.replace("'", "&#39;").replace("\n", " ")
                 if self.extract_images:
                     image = self.extract_image(document, ref_block_id)
                     image_name = f"{ref_block_id.to_path()}.{settings.OUTPUT_IMAGE_FORMAT.lower()}"
                     images[image_name] = image
+                    img_html = f"<img src='{image_name}' alt='{alt_attr}'>"
+                    if long_description:
+                        img_html += f"<aside class='image-long-description'>{long_description}</aside>"
                     element = BeautifulSoup(
-                        f"<p>{content}<img src='{image_name}'></p>", "html.parser"
+                        f"<p>{content}{img_html}</p>", "html.parser"
                     )
                     ref.replace_with(self.insert_block_id(element, ref_block_id))
                 else:
-                    # This will be the image description if using llm mode, or empty if not
-                    element = BeautifulSoup(f"{content}", "html.parser")
+                    # No image file; emit the long description (if any) as a hidden aside
+                    # so text-only consumers still get the LLM-generated context.
+                    extra = ""
+                    if long_description:
+                        extra = f"<aside class='image-long-description'>{long_description}</aside>"
+                    element = BeautifulSoup(f"{content}{extra}", "html.parser")
                     ref.replace_with(self.insert_block_id(element, ref_block_id))
             elif ref_block_id.block_type in self.page_blocks:
                 images.update(sub_images)

--- a/marker/renderers/markdown.py
+++ b/marker/renderers/markdown.py
@@ -229,6 +229,15 @@ class Markdownify(MarkdownConverter):
         else:
             return text
 
+    def convert_aside(self, el, text, parent_tags):
+        classes = el.get("class") or []
+        if "image-long-description" in classes:
+            # Emit as an HTML comment so it's invisible to human readers but
+            # still visible to any LLM ingesting the raw markdown.
+            comment_body = text.strip().replace("--", "—")
+            return f"\n\n<!-- image-long-description: {comment_body} -->\n\n"
+        return text
+
     def escape(self, text, parent_tags=None):
         text = super().escape(text, parent_tags)
         if self.options["escape_dollars"]:

--- a/marker/schema/blocks/figure.py
+++ b/marker/schema/blocks/figure.py
@@ -5,6 +5,8 @@ from marker.schema.blocks import Block
 class Figure(Block):
     block_type: BlockTypes = BlockTypes.Figure
     description: str | None = None
+    short_caption: str | None = None
+    long_description: str | None = None
     html: str | None = None
     block_description: str = "A chart or other image that contains data."
 

--- a/marker/schema/blocks/picture.py
+++ b/marker/schema/blocks/picture.py
@@ -5,6 +5,8 @@ from marker.schema.blocks import Block
 class Picture(Block):
     block_type: BlockTypes = BlockTypes.Picture
     description: str | None = None
+    short_caption: str | None = None
+    long_description: str | None = None
     block_description: str = "An image block that represents a picture."
     html: str | None = None
 


### PR DESCRIPTION
New opt-in processor (LLMImageContextDescriptionProcessor) that describes every Picture/Figure block with an LLM, supplying the page's extracted markdown and the page image as context. Returns a short caption (rendered as image alt text) and a long description (rendered as a hidden HTML comment), so a text-only LLM reading the markdown alone can understand the visual content without a multimodal pipeline.

- New flag --llm_image_context, orthogonal to --use_llm; works whether or not image extraction is enabled.
- Picture/Figure blocks gain short_caption + long_description fields.
- HTML renderer emits alt text + a hidden <aside>; markdown renderer converts that aside into an HTML comment.
- Gemini service activates for this flag independently of --use_llm.

Developed with assistance from Claude (Claude Code).