### PR TITLE
fix: respect Gemini API RetryInfo delay on 429 responses

### DIFF
--- a/marker/services/gemini.py
+++ b/marker/services/gemini.py
@@ -30,6 +30,31 @@ class BaseGeminiService(BaseService):
         img.save(image_bytes, format="WEBP")
         return image_bytes.getvalue()
 
+    @staticmethod
+    def _get_retry_delay(error: APIError) -> float | None:
+        details = getattr(error, "details", None)
+        if not isinstance(details, dict):
+            return None
+        # Response may nest under 'error' key or be flat
+        error_details = (
+            details.get("error", {}).get("details")
+            or details.get("details")
+        )
+        if not isinstance(error_details, list):
+            return None
+        for entry in error_details:
+            if not isinstance(entry, dict):
+                continue
+            if not entry.get("@type", "").endswith("RetryInfo"):
+                continue
+            delay_str = entry.get("retryDelay", "")
+            if isinstance(delay_str, str) and delay_str.endswith("s"):
+                try:
+                    return float(delay_str[:-1])
+                except ValueError:
+                    continue
+        return None
+
     def get_google_client(self, timeout: int):
         raise NotImplementedError
 
@@ -101,7 +126,7 @@ class BaseGeminiService(BaseService):
                         )
                         break
                     else:
-                        wait_time = tries * self.retry_wait_time
+                        wait_time = self._get_retry_delay(e) or tries * self.retry_wait_time
                         logger.warning(
                             f"APIError: {e}. Retrying in {wait_time} seconds... (Attempt {tries}/{total_tries})",
                         )


### PR DESCRIPTION
While using this on the gemini free tier, I was hitting the tier rate limits. I saw the api was replying with info about when to retry, but we were ignoring it. This PR uses the retry info if it's available, so we can play nicer with the rate limits.

Somewhat frustratingly, there is a lingering PR that has yet to be reviewed that implements this upstream. But in the meantime we can do it here.


clanker generated below

---

## Summary

- Parse `retryDelay` from `google.rpc.RetryInfo` in 429 error responses and use it as the retry sleep duration
- Falls back to the existing linear backoff (`tries * retry_wait_time`) when the field is absent or malformed
- Handles both response shapes (`{'error': {'details': [...]}}` and flat `{'details': [...]}`)

This avoids burning through all retries with fixed backoff when the API tells you exactly how long to wait — particularly useful on the free tier where per-minute rate limits are tight.

Ref: https://github.com/googleapis/python-genai/pull/2114 (same fix at the SDK transport layer, not yet merged)
Fixes: https://github.com/datalab-to/marker/issues/490