### PR TITLE
Fix misspellings of 'compatible'/'compatibility' in OpenAIService

### DIFF
--- a/marker/services/openai.py
+++ b/marker/services/openai.py
@@ -27,20 +27,20 @@ class OpenAIService(BaseService):
     ] = None
     openai_image_format: Annotated[
         str,
-        "The image format to use for the OpenAI-like service. Use 'png' for better compatability",
+        "The image format to use for the OpenAI-like service. Use 'png' for better compatibility",
     ] = "webp"
 
     def process_images(self, images: List[Image.Image]) -> List[dict]:
         """
         Generate the base-64 encoded message to send to an
-        openAI-compatabile multimodal model.
+        OpenAI-compatible multimodal model.
 
         Args:
             images: Image or list of PIL images to include
-            format: Format to use for the image; use "png" for better compatability.
+            format: Format to use for the image; use "png" for better compatibility.
 
         Returns:
-            A list of OpenAI-compatbile multimodal messages containing the base64-encoded images.
+            A list of OpenAI-compatible multimodal messages containing the base64-encoded images.
         """
         if isinstance(images, Image.Image):
             images = [images]


### PR DESCRIPTION
## Summary

Fixes four spelling errors of *compatible*/*compatibility* in `marker/services/openai.py`. One of them is in a **user-facing config field description** (`openai_image_format`), so it shows up in `config --help` output; the other three are in the `process_images` docstring.

| Line | Before | After |
|------|--------|-------|
| 30 | `...for better **compatability**` | `...for better **compatibility**` |
| 36 | `**openAI-compatabile** multimodal model.` | `**OpenAI-compatible** multimodal model.` |
| 40 | `...use "png" for better **compatability**.` | `...use "png" for better **compatibility**.` |
| 43 | `A list of **OpenAI-compatbile** multimodal messages...` | `A list of **OpenAI-compatible** multimodal messages...` |

## Notes

- Documentation/string-only change — no behavior change.
- Verified the file still parses (`python -c "import ast; ast.parse(...)"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)