### PR TITLE
fix: only strip the leading bullet from a ListItem first line

### DIFF
--- a/marker/schema/blocks/listitem.py
+++ b/marker/schema/blocks/listitem.py
@@ -13,7 +13,7 @@ def replace_bullets(child_blocks):
 
     if first_block is not None and first_block.id.block_type == BlockTypes.Line:
         bullet_pattern = r"(^|[\n ]|<[^>]*>)[•●○ഠ ം◦■▪▫–—-]( )"
-        first_block.html = re.sub(bullet_pattern, r"\1\2", first_block.html)
+        first_block.html = re.sub(bullet_pattern, r"\1\2", first_block.html, count=1)
 
 
 class ListItem(Block):

--- a/tests/schema/blocks/test_listitem.py
+++ b/tests/schema/blocks/test_listitem.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+from marker.schema import BlockTypes
+from marker.schema.blocks.listitem import replace_bullets
+
+
+def test_replace_bullets_keeps_inner_dashes():
+    # Regression for #1024: removing the bullet must not drop a dash inside the text.
+    line = SimpleNamespace(
+        children=[],
+        id=SimpleNamespace(block_type=BlockTypes.Line),
+        html="• He paused — then left.",
+    )
+
+    replace_bullets([line])
+
+    assert "•" not in line.html
+    assert line.html.strip() == "He paused — then left."


### PR DESCRIPTION
### Problem

In `replace_bullets`, the bullet-stripping `re.sub` ran without a `count`, so it
replaced every bullet/dash that sits between spaces on a list item's first line,
not just the leading bullet. The character class includes the en dash, em dash,
and hyphen, so a list item whose text contains a spaced dash mid-line had that
dash silently deleted.

For example, a dialogue line rendered as a list item lost its internal dash:

- before: `I saw him` ... `he interrupted.` (the mid-sentence dash was removed)

### Fix

Add `count=1` so only the leftmost match is replaced, which for a real list item
is the leading bullet. Internal dashes are preserved.

### Test

Adds `tests/schema/blocks/test_listitem.py`, a pure-logic regression test that
runs `replace_bullets` on a minimal Line block and checks the leading bullet is
removed while a spaced dash inside the text survives. It fails on the current
code and passes with this change, and pulls in no model weights.

Fixes #1024
