### PR TITLE
Add Atlas Cloud LLM service

### DIFF
--- a/marker/services/atlascloud.py
+++ b/marker/services/atlascloud.py
@@ -1,0 +1,58 @@
+import os
+from typing import Annotated
+
+import openai
+
+from marker.services.openai import OpenAIService
+
+
+class AtlasCloudService(OpenAIService):
+    """OpenAI-compatible LLM service backed by Atlas Cloud."""
+
+    atlascloud_base_url: Annotated[
+        str, "The Atlas Cloud OpenAI-compatible API base url. No trailing slash."
+    ] = "https://api.atlascloud.ai/v1"
+    atlascloud_model: Annotated[str, "The Atlas Cloud multimodal model id to use."] = (
+        "google/gemini-3.5-flash"
+    )
+    atlascloud_api_key: Annotated[
+        str, "The Atlas Cloud API key (falls back to $ATLASCLOUD_API_KEY or $ATLAS_CLOUD_API_KEY)."
+    ] = None
+    atlascloud_image_format: Annotated[
+        str, "Image format sent to the model. Use 'png' for broad compatibility."
+    ] = "png"
+
+    def __init__(self, config=None):
+        if config is None:
+            config = {}
+        if isinstance(config, dict):
+            config = self._with_env_defaults(config)
+        super().__init__(config)
+        self.atlascloud_base_url = self.atlascloud_base_url.rstrip("/")
+        self.openai_base_url = self.atlascloud_base_url
+        self.openai_model = self.atlascloud_model
+        self.openai_api_key = self.atlascloud_api_key
+        self.openai_image_format = self.atlascloud_image_format
+
+    def _with_env_defaults(self, config: dict) -> dict:
+        atlascloud_api_key = os.environ.get("ATLASCLOUD_API_KEY") or os.environ.get(
+            "ATLAS_CLOUD_API_KEY"
+        )
+        atlascloud_base_url = (
+            os.environ.get("ATLASCLOUD_API_BASE")
+            or os.environ.get("ATLASCLOUD_BASE_URL")
+            or os.environ.get("ATLAS_CLOUD_API_BASE")
+            or os.environ.get("ATLAS_CLOUD_BASE_URL")
+        )
+        updates = dict(config)
+        if atlascloud_api_key and not updates.get("atlascloud_api_key"):
+            updates["atlascloud_api_key"] = atlascloud_api_key
+        if atlascloud_base_url and not updates.get("atlascloud_base_url"):
+            updates["atlascloud_base_url"] = atlascloud_base_url.rstrip("/")
+        return updates
+
+    def get_client(self) -> openai.OpenAI:
+        return openai.OpenAI(
+            api_key=self.atlascloud_api_key,
+            base_url=self.openai_base_url,
+        )

--- a/tests/services/test_service_init.py
+++ b/tests/services/test_service_init.py
@@ -1,6 +1,8 @@
 import pytest
 
 from marker.converters.pdf import PdfConverter
+from marker.services import atlascloud as atlascloud_module
+from marker.services.atlascloud import AtlasCloudService
 from marker.services.gemini import GoogleGeminiService
 from marker.services.ollama import OllamaService
 from marker.services.vertex import GoogleVertexService
@@ -66,6 +68,52 @@ def test_llm_ollama(pdf_converter: PdfConverter, temp_doc):
 def test_llm_openai(pdf_converter: PdfConverter, temp_doc):
     assert pdf_converter.artifact_dict["llm_service"] is not None
     assert isinstance(pdf_converter.llm_service, OpenAIService)
+
+
+@pytest.mark.output_format("markdown")
+@pytest.mark.config(
+    {
+        "page_range": [0],
+        "use_llm": True,
+        "llm_service": "marker.services.atlascloud.AtlasCloudService",
+        "atlascloud_api_key": "test",
+    }
+)
+def test_llm_atlascloud(pdf_converter: PdfConverter, temp_doc):
+    assert pdf_converter.artifact_dict["llm_service"] is not None
+    assert isinstance(pdf_converter.llm_service, AtlasCloudService)
+    assert pdf_converter.llm_service.openai_base_url == "https://api.atlascloud.ai/v1"
+    assert pdf_converter.llm_service.openai_model == "google/gemini-3.5-flash"
+
+
+def test_atlascloud_service_uses_env_aliases(monkeypatch):
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "env-test")
+    monkeypatch.setenv("ATLAS_CLOUD_BASE_URL", "https://atlas.example/v1/")
+
+    service = AtlasCloudService()
+
+    assert service.atlascloud_api_key == "env-test"
+    assert service.openai_api_key == "env-test"
+    assert service.atlascloud_base_url == "https://atlas.example/v1"
+    assert service.openai_base_url == "https://atlas.example/v1"
+
+
+def test_atlascloud_service_builds_openai_client(monkeypatch):
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(atlascloud_module.openai, "OpenAI", FakeOpenAI)
+    service = AtlasCloudService({"atlascloud_api_key": "test"})
+
+    assert isinstance(service.get_client(), FakeOpenAI)
+    assert captured == {
+        "api_key": "test",
+        "base_url": "https://api.atlascloud.ai/v1",
+    }
 
 
 @pytest.mark.output_format("markdown")


### PR DESCRIPTION
## Summary

- Add `AtlasCloudService`, an OpenAI-compatible LLM service for Marker accurate mode.
- Default Atlas Cloud to `https://api.atlascloud.ai/v1` and the live-confirmed multimodal model `google/gemini-3.5-flash`.
- Support `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY` plus Atlas Cloud base URL alias environment variables.
- Reuse Marker's existing `OpenAIService` request formatting and structured-output path.

No README/docs/logo changes.

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/marker_pycache python3 -m compileall marker/services/atlascloud.py tests/services/test_service_init.py`
- `UV_CACHE_DIR=/tmp/uv-cache-marker uv run --python /Users/zby/.local/bin/python3.11 --group dev pytest tests/services/test_service_init.py::test_atlascloud_service_uses_env_aliases tests/services/test_service_init.py::test_atlascloud_service_builds_openai_client`
- `uv run --python /Users/zby/.local/bin/python3.11 --with ruff ruff check marker/services/atlascloud.py tests/services/test_service_init.py`
- `git diff --cached --check`
- Atlas Cloud live model catalog returned 436 models and confirmed `google/gemini-3.5-flash` is visible with image input support.

The full `tests/services/test_service_init.py` file could not complete locally because the existing `pdf_dataset` fixture could not access the Hugging Face dataset `datalab-to/pdfs`; the direct AtlasCloud service tests passed.
