### PR TITLE
fix(marginalia): measure margin zones in the blocks' coordinate space (#1072)

### DIFF
--- a/marker/processors/marginalia.py
+++ b/marker/processors/marginalia.py
@@ -57,13 +57,18 @@ class MarginaliaProcessor(BaseProcessor):
             if len(text_blocks) < 2:
                 continue  # single-block pages: nothing is "marginal"
 
-            page_top = page.polygon.bbox[1]
+            # Block polygons are 0-origin within the page, so only the page's
+            # height is taken from its polygon - never its origin. Subtracting
+            # page.polygon.bbox[1] would shift every fraction on pages whose
+            # polygon carries a non-zero CropBox origin (the force_ocr path in
+            # PdfProvider), which is why the sibling processors compare raw
+            # block coordinates against page.polygon.height/width directly.
             page_height = page.polygon.height or 1
 
             def yfrac(b):
                 return (
-                    (b.polygon.bbox[1] - page_top) / page_height,
-                    (b.polygon.bbox[3] - page_top) / page_height,
+                    b.polygon.bbox[1] / page_height,
+                    b.polygon.bbox[3] / page_height,
                 )
 
             # Body = text blocks not fully inside either margin zone. A

--- a/tests/processors/test_marginalia_processor.py
+++ b/tests/processors/test_marginalia_processor.py
@@ -1,0 +1,60 @@
+import pytest
+
+from marker.processors.marginalia import MarginaliaProcessor
+from marker.schema import BlockTypes
+from marker.schema.blocks import Text
+from marker.schema.document import Document
+from marker.schema.groups.page import PageGroup
+from marker.schema.polygon import PolygonBox
+
+# Same rendered layout on every page: a running header at the very top, body
+# text that starts just below it, a tall body paragraph, and a page number.
+# Coordinates are 0-origin within the page, as block polygons always are.
+PAGE_CONTENT_HEIGHT = 711.0
+LAYOUT = [
+    ("Chapter 3 - Results", [63.0, 8.0, 400.0, 22.0]),
+    ("Introductory sentence.", [63.0, 83.2, 500.0, 103.0]),
+    ("Body paragraph. " * 20, [63.0, 120.0, 500.0, 500.0]),
+    ("12", [63.0, 690.0, 200.0, 704.0]),
+]
+
+
+def _build_document(page_bbox):
+    page = PageGroup(page_id=0, polygon=PolygonBox.from_bbox(page_bbox))
+    for text, bbox in LAYOUT:
+        block = page.add_block(Text, PolygonBox.from_bbox(bbox))
+        block.html = text
+        page.add_structure(block)
+    return Document(filepath="test.pdf", pages=[page])
+
+
+def _ignored_texts(document):
+    page = document.pages[0]
+    return {
+        block.raw_text(document).strip()
+        for block in page.contained_blocks(document, [BlockTypes.Text])
+        if block.ignore_for_output
+    }
+
+
+@pytest.mark.cpu
+def test_marginalia_processor_ignores_page_polygon_origin():
+    """A non-zero page-polygon origin must not shift the margin zones.
+
+    PdfProvider assigns page bboxes as [0, 0, w, h] on the pdftext path but as
+    the raw pdfium CropBox on the force_ocr path, so a page polygon can carry a
+    non-zero y origin while its blocks stay 0-origin. Both must classify the
+    same rendering identically.
+    """
+    zero_origin = _build_document([0.0, 0.0, 612.0, PAGE_CONTENT_HEIGHT])
+    shifted_origin = _build_document([0.0, 81.0, 612.0, 81.0 + PAGE_CONTENT_HEIGHT])
+
+    processor = MarginaliaProcessor()
+    processor(zero_origin)
+    processor(shifted_origin)
+
+    # Only the running header and the page number are marginalia; the body
+    # text just below the header must survive on both pages.
+    expected = {"Chapter 3 - Results", "12"}
+    assert _ignored_texts(zero_origin) == expected
+    assert _ignored_texts(shifted_origin) == expected


### PR DESCRIPTION
Fixes #1072.

## The bug

`MarginaliaProcessor` converts each block's vertical position into a fraction of the page, and starts by subtracting the page polygon's own origin:

```python
page_top = page.polygon.bbox[1]
page_height = page.polygon.height or 1

def yfrac(b):
    return (
        (b.polygon.bbox[1] - page_top) / page_height,
        (b.polygon.bbox[3] - page_top) / page_height,
    )
```

Block polygons are 0-origin within the page, so that origin is not part of the space they are measured in. Which origin `page.polygon` carries depends on which extraction path ran, in `marker/providers/pdf.py`:

```python
if self.force_ocr:
    # Manually assign page bboxes, since we can't get them from pdftext
    self.page_bboxes = {i: doc[i].get_bbox() for i in self.page_range}   # raw pdfium CropBox
else:
    ...
    self.page_bboxes = {
        i: [0, 0, page["width"], page["height"]]                          # already 0-origin
        for i, page in zip(self.page_range, page_char_blocks)
    }
```

On the pdftext path `page_top` is always `0`, so the subtraction is a no-op and nobody notices. On the `force_ocr` path the page polygon is the CropBox, so on a PDF whose CropBox has a non-zero origin every fraction is shifted by `-cropbox_y0 / page_height`.

Both directions then misfire: the 8% `header_zone` covers a much larger slice of the real page, so ordinary body text near the top is marked `ignore_for_output = True` and vanishes from every renderer — the block keeps its `polygon`/`bbox` in the JSON but its `html` becomes `""`, with nothing logged — while the genuine footer slides out of the `footer_zone` and is missed.

## The fix

Take only the page's *height* from its polygon and leave the blocks in their own coordinate space. This matches what the sibling processors already do — `text.py` and `list.py` compare raw block coordinates against `page.polygon.height` / `page.polygon.width` with no origin subtraction:

```python
next_block.polygon.x_start < next_page.polygon.width // 2
```

`marginalia.py` was the only place also subtracting `page.polygon.bbox[1]`.

The pdftext path is byte-for-byte unaffected, since `page_top` was already `0` there.

## Verification

Ran the processor against two documents that are the **same rendering**, differing only in the page polygon's origin (`[0, 0, 612, 711]` vs `[0, 81, 612, 792]` — same 711 content height, as in the reported case).

Before, on the shifted page:

```
DROPPED  'Chapter 3 - Results'      <- correct, running header
DROPPED  'Introductory sentence.'   <- WRONG, real body text silently deleted
kept     'Body paragraph...'
kept     '12'                       <- WRONG, real footer missed
```

After, both pages classify identically and correctly:

```
DROPPED  'Chapter 3 - Results'
kept     'Introductory sentence.'
kept     'Body paragraph...'
DROPPED  '12'
```

`tests/processors/test_marginalia_processor.py` encodes exactly that comparison. It fails on `master` and passes with this change. It needs no GPU, models, or fixture PDFs — it builds the two pages from marker's own schema objects — so it is marked `@pytest.mark.cpu` and runs on the CPU CI runner too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
