### PR TITLE
Fix compatibility with pypdfium2 >= 5.0 (get_pos → get_bounds rename)

### DIFF
--- a/marker/providers/pdf.py
+++ b/marker/providers/pdf.py
@@ -380,7 +380,11 @@ class PdfProvider(BaseProvider):
             for img_obj in filter(
                 lambda obj: obj.type == pdfium_c.FPDF_PAGEOBJ_IMAGE, page_objs
             ):
-                img_bbox = PolygonBox.from_bbox(img_obj.get_pos())
+                if hasattr(img_obj, "get_bounds"):
+                    bbox = img_obj.get_bounds()
+                else:
+                    bbox = img_obj.get_pos()
+                img_bbox = PolygonBox.from_bbox(bbox)
                 if page_bbox.intersection_pct(img_bbox) >= self.image_threshold:
                     return False
 


### PR DESCRIPTION
marker/providers/pdf.py calls PdfImage.get_pos(), which was renamed to .get_bounds() in pypdfium2 5.0 (release notes, confirmed a pure rename, not a behavior change). Since pypdfium2 isn't pinned or even declared as a direct dependency here (it comes in transitively via pdftext), any environment that resolves pypdfium2 >= 5.0 hits an AttributeError on every PDF page containing an embedded image:

AttributeError: 'PdfImage' object has no attribute 'get_pos'

This PR:

Adds a compatibility check supporting both API generations, rather than assuming one side of the rename. Suggests adding pypdfium2 as an explicit direct dependency with an appropriate version floor, since marker uses its objects directly and shouldn't rely on getting a compatible version by chance through pdftext.