### PR TITLE
fix(markdown): flag silent tail truncation from the markdownify HTML parse (#1069)

### DIFF
--- a/marker/renderers/markdown.py
+++ b/marker/renderers/markdown.py
@@ -309,6 +309,8 @@ class MarkdownRenderer(HTMLRenderer):
         markdown = self.md_cls.convert(full_html)
         markdown = cleanup_text(markdown)
 
+        truncated = self.detect_truncation(full_html, markdown)
+
         # Ensure we set the correct blanks for pagination markers
         if self.paginate_output:
             if not markdown.startswith("\n\n"):
@@ -316,8 +318,42 @@ class MarkdownRenderer(HTMLRenderer):
             if markdown.endswith(self.page_separator):
                 markdown += "\n\n"
 
+        metadata = self.generate_document_metadata(document, document_output)
+        metadata["markdown_truncated"] = truncated
+
         return MarkdownOutput(
             markdown=markdown,
             images=images,
-            metadata=self.generate_document_metadata(document, document_output),
+            metadata=metadata,
         )
+
+    def detect_truncation(self, full_html: str, markdown: str) -> bool:
+        """Warn when the markdownify pass silently dropped most of the document.
+
+        markdownify re-parses the whole assembled HTML through BeautifulSoup.
+        On some malformed markup (an unclosed ``<script>``/``<style>``, an
+        unterminated comment, ...) the parser treats everything after the bad
+        token as raw CDATA/comment text and discards it, returning a truncated
+        string without raising. The run then exits 0, so a 90% data loss is
+        indistinguishable from success at the API boundary.
+
+        The source length is measured by stripping tags with a regex rather
+        than an HTML parser, so the swallowed tail is still counted; a large
+        shortfall against the rendered markdown flags the truncation both in
+        the logs and in the returned metadata.
+        """
+        source_len = len(re.sub(r"\s+", "", re.sub(r"<[^>]+>", "", full_html)))
+        markdown_len = len(re.sub(r"\s+", "", markdown))
+        if source_len > 500 and markdown_len < source_len * 0.5:
+            logger.warning(
+                "Markdown render retained only %d of ~%d source characters "
+                "(%.0f%%); markdownify's HTML parser likely discarded the tail "
+                "of the document on malformed markup (e.g. an unclosed "
+                "<script>/<style>, comment, or attribute quote). The returned "
+                "markdown is probably truncated.",
+                markdown_len,
+                source_len,
+                100.0 * markdown_len / max(source_len, 1),
+            )
+            return True
+        return False

--- a/tests/renderers/test_markdown_renderer.py
+++ b/tests/renderers/test_markdown_renderer.py
@@ -86,3 +86,28 @@ def test_markdown_renderer_tables(pdf_document):
     renderer = MarkdownRenderer()
     md = renderer(pdf_document).markdown
     assert "54 <i>.45</i> 67<br>89 $x$" in md
+
+
+def test_markdown_renderer_detects_truncation():
+    # No pdf_document / models needed: detect_truncation is a pure post-render
+    # integrity check over the assembled HTML and the produced markdown.
+    renderer = MarkdownRenderer()
+
+    early = "".join(f"<p>Real body paragraph {i}.</p>" for i in range(1, 15))
+    tail = "".join(
+        f"<p>Tail paragraph {i} that the HTML parser silently discards.</p>"
+        for i in range(1, 120)
+    )
+
+    # An unclosed <script> makes BeautifulSoup treat the whole tail as CDATA,
+    # so markdownify returns a truncated string without raising.
+    truncated_html = early + "<script>garbage()" + tail
+    truncated_md = renderer.md_cls.convert(truncated_html)
+    assert "Tail paragraph 100" not in truncated_md
+    assert renderer.detect_truncation(truncated_html, truncated_md) is True
+
+    # The same content without the poisoning token renders in full.
+    intact_html = early + tail
+    intact_md = renderer.md_cls.convert(intact_html)
+    assert "Tail paragraph 100" in intact_md
+    assert renderer.detect_truncation(intact_html, intact_md) is False


### PR DESCRIPTION
## Summary

Fixes #1069. The markdown renderer re-parses the **whole** assembled document HTML through markdownify's BeautifulSoup pass (`MarkdownRenderer.__call__` → `self.md_cls.convert(full_html)`). On some malformed markup the parser silently swallows the rest of the document and returns a truncated string **without raising**, so the run exits 0 while dropping most of the content — a 90% data loss indistinguishable from success at the API boundary.

I confirmed the mechanism against marker's own `markdownify` config (1.2.x, `bs4_options="html.parser"`). Feeding a document with real body text after one of these tokens drops the entire remainder:

| trigger | `html.parser` retains tail? |
|---|---|
| unclosed `<script>` | ❌ swallowed |
| unclosed `<style>` | ❌ swallowed |
| unterminated comment `<!--` | ❌ swallowed |

(These are genuinely ambiguous unterminated-CDATA/comment constructs — switching to `lxml` does **not** help; it drops the tail on unclosed comments *instead*, so a parser swap just trades one truncation for another.)

## Fix

Per the reporter's suggested direction, add a parser-agnostic post-render integrity check (`MarkdownRenderer.detect_truncation`). It measures the source text length by stripping tags with a regex — **not** an HTML parser, so the swallowed tail is still counted — and compares it to the rendered markdown. When the source is non-trivial (>500 chars) and the markdown retains under half of it, it emits a `logger.warning` and records `markdown_truncated: true` in the output metadata.

This converts a silent ~90% data loss into a visible, programmatically-checkable one, without touching any existing output for well-formed documents. Validated over normal docs (ratio ≈1.0, no warning), truncated docs (ratio ≈0.07, warns), math/table-heavy and small docs (no false positives).

## Test

`tests/renderers/test_markdown_renderer.py::test_markdown_renderer_detects_truncation` — fixture-free (no models); asserts the flag fires on an unclosed-`<script>` truncation and stays quiet on the same content intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
