### PR TITLE
fix(ollama): send full JSON schema and omit empty images (#1060, #1061)

### DIFF
--- a/marker/services/ollama.py
+++ b/marker/services/ollama.py
@@ -34,12 +34,10 @@ class OllamaService(BaseService):
         url = f"{self.ollama_base_url}/api/generate"
         headers = {"Content-Type": "application/json"}
 
+        # Pass the full JSON schema through so nested models keep their
+        # ``$defs``/``$ref`` definitions; hand-picking ``properties``/``required``
+        # drops those and Ollama rejects the resulting structured output.
         schema = response_schema.model_json_schema()
-        format_schema = {
-            "type": "object",
-            "properties": schema["properties"],
-            "required": schema["required"],
-        }
 
         image_bytes = self.format_image_for_llm(image)
 
@@ -47,9 +45,14 @@ class OllamaService(BaseService):
             "model": self.ollama_model,
             "prompt": prompt,
             "stream": False,
-            "format": format_schema,
-            "images": image_bytes,
+            "format": schema,
         }
+
+        # Only send ``images`` for multimodal prompts. Text-only processors
+        # produce an empty list, and some Ollama backends reject that as a
+        # malformed multimodal request, corrupting the response.
+        if image_bytes:
+            payload["images"] = image_bytes
 
         try:
             response = requests.post(url, json=payload, headers=headers)


### PR DESCRIPTION
## What

`OllamaService.__call__` builds its request payload in two ways that break valid calls:

1. **Structured output drops nested schema definitions (#1060).** The `format` field is hand-assembled from only `properties` and `required`:

   ```python
   format_schema = {
       "type": "object",
       "properties": schema["properties"],
       "required": schema["required"],
   }
   ```

   Any `response_schema` that nests another `BaseModel` emits its sub-models under `$defs` and references them with `$ref`. Copying just `properties`/`required` discards `$defs`, so Ollama receives dangling `$ref`s and rejects the structured request. This passes the full `response_schema.model_json_schema()` as the format instead, which keeps `$defs`/`$ref` intact (extra keys such as `title` are harmless to Ollama). Flat schemas are unaffected.

2. **Text-only prompts always send an empty `images` field (#1061).** `format_image_for_llm` returns `[]` when there is no image, and the payload unconditionally set `"images": image_bytes`. Some Ollama backends treat the presence of an `images` key as a multimodal request and reject or corrupt the response when the list is empty — this hits text-only processors (e.g. the section-header processor). The `images` key is now only added when there is at least one image.

## Fixes

Fixes #1060
Fixes #1061

## Notes

Change is confined to `marker/services/ollama.py`; both are backward compatible for flat schemas and multimodal prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
