### PR TITLE
fix(layout): drop duplicate table-family detections of one region (#1078)

### DIFF
--- a/marker/builders/layout.py
+++ b/marker/builders/layout.py
@@ -17,6 +17,16 @@ from marker.schema.registry import get_block_class
 
 logger = get_logger()
 
+# Block types that are all rendered as HTML tables by the TableProcessor. When
+# the layout model emits two heavily-overlapping boxes from this set for one
+# region (e.g. a questionnaire tagged as both Table and Form), both render and
+# the same table is duplicated in the output.
+TABLE_FAMILY_TYPES = (
+    BlockTypes.Table,
+    BlockTypes.Form,
+    BlockTypes.TableOfContents,
+)
+
 
 class LayoutBuilder(BaseBuilder):
     """
@@ -72,6 +82,13 @@ class LayoutBuilder(BaseBuilder):
     max_expand_frac: Annotated[
         float, "The maximum fraction to expand the layout box bounds by"
     ] = 0.05
+    table_merge_overlap_pct: Annotated[
+        float,
+        "Two table-family layout boxes (Table/Form/TableOfContents) whose mutual "
+        "overlap fraction both exceed this value are treated as duplicate "
+        "detections of the same region; the lower-confidence one is dropped so "
+        "the region is not rendered as a table twice.",
+    ] = 0.75
 
     def __init__(
         self,
@@ -107,7 +124,58 @@ class LayoutBuilder(BaseBuilder):
         else:
             layout_results = self.surya_layout(document.pages, provider)
         self.add_blocks_to_pages(document.pages, layout_results)
+        self.merge_overlapping_table_blocks(document)
         self.expand_layout_blocks(document)
+
+    def merge_overlapping_table_blocks(self, document: Document):
+        """Drop duplicate table-family detections. The layout model can tag one
+        region as both a Table and a Form (near-identical boxes); both are
+        rendered as HTML tables by the TableProcessor, so the same table appears
+        twice in the output. When two table-family boxes mutually overlap above
+        table_merge_overlap_pct, keep the higher-confidence one and remove the
+        other."""
+        for page in document.pages:
+            if not page.structure:
+                continue
+
+            table_blocks = [
+                block
+                for block in (document.get_block(bid) for bid in page.structure)
+                if block is not None and block.block_type in TABLE_FAMILY_TYPES
+            ]
+
+            remove_ids = []
+            for i, block in enumerate(table_blocks):
+                if block.id in remove_ids:
+                    continue
+                for other in table_blocks[i + 1 :]:
+                    if other.id in remove_ids:
+                        continue
+                    if (
+                        block.polygon.intersection_pct(other.polygon)
+                        >= self.table_merge_overlap_pct
+                        and other.polygon.intersection_pct(block.polygon)
+                        >= self.table_merge_overlap_pct
+                    ):
+                        loser = (
+                            other
+                            if self._layout_confidence(block)
+                            >= self._layout_confidence(other)
+                            else block
+                        )
+                        loser.removed = True
+                        remove_ids.append(loser.id)
+                        if loser.id == block.id:
+                            break
+
+            if remove_ids:
+                page.remove_structure_items(remove_ids)
+
+    @staticmethod
+    def _layout_confidence(block) -> float:
+        if block.top_k:
+            return block.top_k.get(block.block_type, 1.0)
+        return 1.0
 
     def forced_layout(self, pages: List[PageGroup]) -> List[LayoutResult]:
         layout_results = []

--- a/tests/builders/test_layout_table_form_dedup.py
+++ b/tests/builders/test_layout_table_form_dedup.py
@@ -1,0 +1,83 @@
+import pytest
+
+from marker.builders.layout import LayoutBuilder
+from marker.schema import BlockTypes
+from marker.schema.document import Document
+from marker.schema.groups.page import PageGroup
+from marker.schema.polygon import PolygonBox
+from marker.schema.registry import get_block_class
+
+
+def _build_page_with_table_and_form():
+    """One region on a page detected as BOTH a Table and a Form with
+    near-identical boxes (reproduces issue #1078)."""
+    W, H = 600, 800
+    page = PageGroup(page_id=0, polygon=PolygonBox.from_bbox([0, 0, W, H]))
+
+    table_cls = get_block_class(BlockTypes.Table)
+    form_cls = get_block_class(BlockTypes.Form)
+
+    table = page.add_block(table_cls, PolygonBox.from_bbox([50, 100, 550, 400]))
+    table.top_k = {BlockTypes.Table: 0.9}
+    table.html = "<table><tr><td>x</td></tr></table>"
+    page.add_structure(table)
+
+    # Almost the same box, one pixel off - the Form detection.
+    form = page.add_block(form_cls, PolygonBox.from_bbox([51, 101, 549, 399]))
+    form.top_k = {BlockTypes.Form: 0.6}
+    form.html = "<table><tr><td>x</td></tr></table>"
+    page.add_structure(form)
+
+    doc = Document(filepath="synthetic.pdf", pages=[page])
+    return doc, page, table, form
+
+
+@pytest.mark.cpu
+def test_overlapping_table_and_form_deduped():
+    doc, page, table, form = _build_page_with_table_and_form()
+
+    table_family = {BlockTypes.Table, BlockTypes.Form, BlockTypes.TableOfContents}
+    before = [
+        page.get_block(bid)
+        for bid in page.structure
+        if page.get_block(bid).block_type in table_family
+    ]
+    assert len(before) == 2  # bug precondition: duplicate detections present
+
+    builder = LayoutBuilder.__new__(LayoutBuilder)
+    builder.table_merge_overlap_pct = 0.75
+    builder.merge_overlapping_table_blocks(doc)
+
+    after = [
+        page.get_block(bid)
+        for bid in page.structure
+        if page.get_block(bid).block_type in table_family
+    ]
+    # Only the higher-confidence Table survives; the Form duplicate is removed.
+    assert len(after) == 1
+    assert after[0].id == table.id
+    assert form.removed is True
+    assert table.removed is False
+
+
+@pytest.mark.cpu
+def test_non_overlapping_tables_are_kept():
+    W, H = 600, 800
+    page = PageGroup(page_id=0, polygon=PolygonBox.from_bbox([0, 0, W, H]))
+    table_cls = get_block_class(BlockTypes.Table)
+
+    t1 = page.add_block(table_cls, PolygonBox.from_bbox([50, 100, 550, 300]))
+    t1.top_k = {BlockTypes.Table: 0.9}
+    page.add_structure(t1)
+    t2 = page.add_block(table_cls, PolygonBox.from_bbox([50, 400, 550, 600]))
+    t2.top_k = {BlockTypes.Table: 0.9}
+    page.add_structure(t2)
+
+    doc = Document(filepath="synthetic.pdf", pages=[page])
+
+    builder = LayoutBuilder.__new__(LayoutBuilder)
+    builder.table_merge_overlap_pct = 0.75
+    builder.merge_overlapping_table_blocks(doc)
+
+    assert len([bid for bid in page.structure]) == 2
+    assert t1.removed is False and t2.removed is False


### PR DESCRIPTION
## Problem

Fixes #1078. On some questionnaire/form PDFs the layout model emits **two heavily-overlapping boxes for one region** — one labeled `Table`, one labeled `Form` — with near-identical bounding boxes. `Table`, `Form` and `TableOfContents` are all `BaseTable` subclasses handled by the same `TableProcessor` (`block_types = (Table, TableOfContents, Form)`), so both boxes render as identical HTML tables and **the same table is emitted twice** in the output.

`add_blocks_to_pages` adds every layout box as its own structure block with no cross-box overlap check, and there is no later pass that removes a conflicting-type duplicate (`StructureBuilder` only groups captions/lists; `LineBuilder.flag_bad_blocks` only suppresses OCR of empty boxes). So nothing ever dedupes the pair.

## Fix

Add a small `merge_overlapping_table_blocks` pass in `LayoutBuilder`, run right after `add_blocks_to_pages` (before line building / OCR / table rendering, so the loser never gets lines or renders). For any two table-family boxes whose overlap fraction exceeds `table_merge_overlap_pct` (default **0.75**) **in both directions** — i.e. genuine duplicate detections of the same region, not legitimate containment or adjacency — it keeps the higher-**layout-confidence** box (`block.top_k`) and marks the other `removed`, dropping it from the page structure.

Scoping to the `{Table, Form, TableOfContents}` family (already a first-class grouping in marker) and requiring high *mutual* overlap means it cannot fire on unrelated adjacent boxes; the confidence tie-break avoids an arbitrary type preference. The threshold is exposed as a config field so it can be tuned/disabled.

## Test

`tests/builders/test_layout_table_form_dedup.py` (`@pytest.mark.cpu`, fully synthetic — no model/fixture):
- overlapping `Table` (conf 0.9) + `Form` (conf 0.6) → only the higher-confidence `Table` survives, the `Form` duplicate is `removed`;
- two non-overlapping tables → both kept (guards against over-removal).

Verified locally against the current `master` (`marker/builders/layout.py` unchanged from the installed 2.0.0 build): the test passes with the patch and fails without it (the duplicate `Form` remains in `page.structure`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
