### PR TITLE
fix(llm): strip the markdown code fence by prefix, not by character set

### DIFF
--- a/marker/processors/llm/llm_complex.py
+++ b/marker/processors/llm/llm_complex.py
@@ -7,6 +7,7 @@ from marker.processors.llm import PromptData, BaseLLMSimpleBlockProcessor
 
 from marker.schema import BlockTypes
 from marker.schema.document import Document
+from marker.util import strip_code_fence
 
 
 class LLMComplexRegionProcessor(BaseLLMSimpleBlockProcessor):
@@ -86,7 +87,7 @@ Output:
             return
 
         # Convert LLM markdown to html
-        corrected_markdown = corrected_markdown.strip().lstrip("```markdown").rstrip("```").strip()
+        corrected_markdown = strip_code_fence(corrected_markdown, "markdown")
         block.html = markdown2.markdown(corrected_markdown, extras=["tables"])
 
 class ComplexSchema(BaseModel):

--- a/marker/processors/llm/llm_handwriting.py
+++ b/marker/processors/llm/llm_handwriting.py
@@ -4,6 +4,7 @@ from marker.processors.llm import PromptData, BaseLLMSimpleBlockProcessor, Block
 
 from marker.schema import BlockTypes
 from marker.schema.document import Document
+from marker.util import strip_code_fence
 
 from typing import Annotated, List
 
@@ -78,7 +79,7 @@ Formatting should be in markdown, with the following rules:
             block.update_metadata(llm_error_count=1)
             return
 
-        markdown = markdown.strip().lstrip("```markdown").rstrip("```").strip()
+        markdown = strip_code_fence(markdown, "markdown")
         block.html = markdown2.markdown(markdown, extras=["tables"])
 
 class HandwritingSchema(BaseModel):

--- a/marker/util.py
+++ b/marker/util.py
@@ -176,3 +176,22 @@ def unwrap_math(text: str, math_symbols: List[str] = MATH_SYMBOLS) -> str:
 
     # Otherwise, return as-is
     return text
+
+
+def strip_code_fence(text: str, lang: str = "") -> str:
+    """Remove a leading ```<lang> fence and a trailing ``` fence, if present.
+
+    ``str.lstrip``/``str.rstrip`` take a *set of characters* rather than a
+    prefix/suffix, so ``text.lstrip("```markdown")`` also eats any leading
+    run of ``` ` m a r k d o w n ``` characters from unfenced content -- for
+    example ``"and the results".lstrip("```markdown")`` returns
+    ``"the results"``.
+    """
+    text = text.strip()
+    for prefix in (f"```{lang}", "```"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+            break
+    if text.endswith("```"):
+        text = text[: -len("```")]
+    return text.strip()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,26 @@
+import pytest
+
+from marker.util import strip_code_fence
+
+
+@pytest.mark.parametrize(
+    "text,lang,expected",
+    [
+        # Fenced responses are unwrapped, with or without a language tag.
+        ("```markdown\n# Title\n```", "markdown", "# Title"),
+        ("```\n# Title\n```", "markdown", "# Title"),
+        ("```html\n<table></table>\n```", "html", "<table></table>"),
+        ("  ```html\n<table></table>\n```  ", "html", "<table></table>"),
+        # Unfenced responses are returned untouched, even when they start with
+        # characters that appear in the fence marker. `lstrip` would eat those.
+        ("and the results were clear", "markdown", "and the results were clear"),
+        ("a photo of a dog", "markdown", "a photo of a dog"),
+        ("normally we do X", "markdown", "normally we do X"),
+        ("markdown", "markdown", "markdown"),
+        ("the table", "html", "the table"),
+        ("html tags here", "html", "html tags here"),
+        ("<table></table>", "html", "<table></table>"),
+    ],
+)
+def test_strip_code_fence(text, lang, expected):
+    assert strip_code_fence(text, lang) == expected


### PR DESCRIPTION
### Problem

`llm_complex.py` and `llm_handwriting.py` unwrap the model's answer with:

```python
corrected_markdown = corrected_markdown.strip().lstrip("```markdown").rstrip("```").strip()
```

`str.lstrip` takes a **set of characters**, not a prefix. Once the literal fence
is consumed it keeps eating any leading run of `` ` ``, `m`, `a`, `r`, `k`, `d`,
`o`, `w`, `n`. Both processors request a structured JSON field
(`ComplexSchema.corrected_markdown`, `HandwritingSchema.markdown`), so the
common case is an answer with **no fence at all** — and then the strip chews
straight into real content:

| model output | current result |
|---|---|
| `and the results were clear` | `the results were clear` |
| `a photo of a dog` | `photo of a dog` |
| `normally we do X` | `lly we do X` |
| `word wrap` | `wrap` |
| `markdown` | `` (empty) |

The result is written directly to `block.html`, so a corrected block silently
loses its opening word — or, in the last case, the whole block.

### Fix

Add `strip_code_fence(text, lang)` to `marker/util.py`, which removes an actual
leading ` ```<lang> ` (falling back to a bare ` ``` `) and a trailing ` ``` `,
and use it at the two call sites. Fenced input behaves exactly as before; only
unfenced input changes.

### Scope

The equivalent ` ```html ` call sites in `llm_form.py` / `llm_table.py` have the
same defect, but they are already addressed by the open #964, so this PR leaves
those two files untouched — there is no file overlap between the two PRs.

### Verification

`tests/test_util.py` covers both directions. Against the previous expression
6 of the 11 cases fail; with the helper all 11 pass, and the 5 fenced-input
cases pass in both — i.e. no behavior change on the intended path.

```
# pre-patch (old lstrip expression)
6 failed, 5 passed
# post-patch
11 passed
```

`ruff==0.9.10` (the pinned `.pre-commit-config.yaml` version) reports
`All checks passed!` and `2 files already formatted` for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
