### PR TITLE
fix(convert_single): log the actual output format, not always 'markdown' (#1052)

### DIFF
--- a/marker/scripts/convert_single.py
+++ b/marker/scripts/convert_single.py
@@ -39,5 +39,6 @@ def convert_single_cli(fpath: str, **kwargs):
     out_folder = config_parser.get_output_folder(fpath)
     save_output(rendered, out_folder, config_parser.get_base_filename(fpath))
 
-    logger.info(f"Saved markdown to {out_folder}")
+    output_format = config_parser.cli_options["output_format"]
+    logger.info(f"Saved {output_format} output to {out_folder}")
     logger.info(f"Total time: {time.time() - start}")


### PR DESCRIPTION
## Summary

`marker_single` always logs `Saved markdown to <folder>` on completion, even when the output was written as JSON, HTML, or chunks (`--output_format json|html|chunks`). The message is hardcoded and doesn't reflect the actual format, which is confusing when scripting or debugging.

Fixes #1052.

## Change

`marker/scripts/convert_single.py` now reads the selected format from the config parser and logs it:

```python
output_format = config_parser.cli_options["output_format"]
logger.info(f"Saved {output_format} output to {out_folder}")
```

So `--output_format html` now logs `Saved html output to <folder>` instead of `Saved markdown to <folder>`. Default behavior (markdown) still reports `Saved markdown output to <folder>`.

No functional change to the conversion or saved files — logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
