### PR TITLE
fix: default omitted output directory to cwd

### DIFF
--- a/marker/config/parser.py
+++ b/marker/config/parser.py
@@ -26,7 +26,7 @@ class ConfigParser:
             "--output_dir",
             type=click.Path(exists=False),
             required=False,
-            default=settings.OUTPUT_DIR,
+            default=None,
             help="Directory to save output.",
         )(fn)
         fn = click.option("--debug", "-d", is_flag=True, help="Enable debug mode.")(fn)
@@ -94,7 +94,7 @@ class ConfigParser:
 
     def generate_config_dict(self) -> Dict[str, any]:
         config = {}
-        output_dir = self.cli_options.get("output_dir", settings.OUTPUT_DIR)
+        output_dir = self.get_output_base_dir()
         for k, v in self.cli_options.items():
             # None means "not provided". Explicit falsy values (False, 0) are
             # real settings and must flow through - dropping them made it
@@ -182,7 +182,7 @@ class ConfigParser:
         return PdfConverter
 
     def get_output_folder(self, filepath: str):
-        output_dir = self.cli_options.get("output_dir", settings.OUTPUT_DIR)
+        output_dir = self.get_output_base_dir()
         fname_base = os.path.splitext(os.path.basename(filepath))[0]
         output_dir = os.path.join(output_dir, fname_base)
         os.makedirs(output_dir, exist_ok=True)
@@ -191,3 +191,6 @@ class ConfigParser:
     def get_base_filename(self, filepath: str):
         basename = os.path.basename(filepath)
         return os.path.splitext(basename)[0]
+
+    def get_output_base_dir(self):
+        return self.cli_options.get("output_dir") or os.getcwd()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -54,6 +54,7 @@ def test_config_parser():
 def test_config_none():
     kwargs = capture_kwargs(["test"])
 
+    assert kwargs["output_dir"] is None
     for key in crawler.attr_set:
         # We force some options to become flags for ease of use on the CLI
         value = None
@@ -76,3 +77,17 @@ def test_config_force_ocr():
 
     # Validate kwarg capturing
     assert config_dict["force_ocr"]
+
+
+def test_output_folder_defaults_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    parser = ConfigParser({"output_dir": None})
+
+    assert parser.get_output_folder("/tmp/example.pdf") == str(tmp_path / "example")
+
+
+def test_output_folder_uses_explicit_output_dir(tmp_path):
+    output_dir = tmp_path / "out"
+    parser = ConfigParser({"output_dir": str(output_dir)})
+
+    assert parser.get_output_folder("/tmp/example.pdf") == str(output_dir / "example")


### PR DESCRIPTION
Fixes #1055.

## What changed

- Leave `--output_dir` unset instead of defaulting to the package-level `conversion_results` directory.
- Resolve an omitted output directory to the current working directory.
- Preserve explicit `--output_dir` behavior.
- Add regression tests for the default and explicit paths.

The output option is provided by the shared CLI parser, so the corrected default applies consistently to both single-file and batch entry points.

## Why

With an installed package, the old default can write under `site-packages/conversion_results`, which is surprising and can be unwritable.

## Validation

- `.venv/bin/pytest tests/config/test_config.py -q` — 6 passed
- `git diff --check`

An end-to-end PDF conversion was not run because it would require loading the full model stack; the focused tests cover path resolution without model inference.
